### PR TITLE
Grazing overhaul

### DIFF
--- a/ST_indivs.c
+++ b/ST_indivs.c
@@ -254,13 +254,12 @@ void indiv_proportion_Grazing( IndivType *ndv, RealF proportionGrazing)
 {
     /*======================================================*/
     /* PURPOSE */
-    /* Do individual grazing proportionally and adjust relative sizes of the
+    /* Implement grazing for each individual and adjust relative sizes of the
      * RGroup and Species downward proportionally by amount of growth the 
-     * individual experienced this year.
-     * Also keep up with survivorship data.
-     */
+     * individual experienced this year. Also keep up with survivorship data.*/
     /* HISTORY */
     /* 1st Nov 2015- AT */
+    /* 14th Aug 2018 - CH */
     /*------------------------------------------------------*/
 
 #define xF_DELTA (20*F_DELTA)
@@ -269,7 +268,6 @@ void indiv_proportion_Grazing( IndivType *ndv, RealF proportionGrazing)
 	( (sizeof(x) == sizeof(float)) \
 			? ((x)>-xF_DELTA && (x)<xF_DELTA) \
 					: ((x)>-xD_DELTA && (x)<xD_DELTA) )
-
 
     RealF grazing_reduce = -(ndv->normal_growth * proportionGrazing);
     //	printf("inside indiv_proportion_Grazing() old indiv rel_size=%f, grazing_reduce=%f \n",ndv->relsize,grazing_reduce);

--- a/ST_indivs.c
+++ b/ST_indivs.c
@@ -255,7 +255,8 @@ void indiv_proportion_Grazing( IndivType *ndv, RealF proportionGrazing)
     /*======================================================*/
     /* PURPOSE */
     /* Do individual grazing proportionally and adjust relative sizes of the
-     * RGroup and Species downward proportionally by the size of the indiv.
+     * RGroup and Species downward proportionally by amount of growth the 
+     * individual experienced this year.
      * Also keep up with survivorship data.
      */
     /* HISTORY */
@@ -270,7 +271,7 @@ void indiv_proportion_Grazing( IndivType *ndv, RealF proportionGrazing)
 					: ((x)>-xD_DELTA && (x)<xD_DELTA) )
 
 
-    RealF grazing_reduce = -(ndv->relsize * proportionGrazing);
+    RealF grazing_reduce = -(ndv->normal_growth * proportionGrazing);
     //	printf("inside indiv_proportion_Grazing() old indiv rel_size=%f, grazing_reduce=%f \n",ndv->relsize,grazing_reduce);
     ndv->relsize = ndv->relsize + grazing_reduce;
     //	printf("inside indiv_proportion_Grazing() new indiv rel_size=%f \n",ndv->relsize);

--- a/ST_resgroups.c
+++ b/ST_resgroups.c
@@ -485,6 +485,8 @@ void rgroup_Grow(void) {
                 ndv->relsize += growth1;
                 //printf("new ndv->relsize  = %f\n, Species = %s \n", Species[sp]->name,ndv->relsize);
 
+		ndv->normal_growth = growth1;
+
                 ndv->growthrate = rate1;
 
                 sppgrowth += growth1;

--- a/ST_resgroups.c
+++ b/ST_resgroups.c
@@ -485,6 +485,7 @@ void rgroup_Grow(void) {
                 ndv->relsize += growth1;
                 //printf("new ndv->relsize  = %f\n, Species = %s \n", Species[sp]->name,ndv->relsize);
 
+		// Saving normal growth for use in grazing.
 		ndv->normal_growth = growth1;
 
                 ndv->growthrate = rate1;

--- a/ST_species.c
+++ b/ST_species.c
@@ -484,12 +484,11 @@ void Species_Proportion_Grazing(const SppIndex sp, RealF proportionGrazing)
 
 	/*======================================================*/
 	/* PURPOSE */
-	/* Proportion Grazing all established individuals in a species at Grazing year.
-	 * Note the special loop construct.  we have to save the
-	 * pointer to next prior to killing because the object
-	 * is deleted. */
+	/* Proportion Grazing on all individuals and on the extra growth stored in
+	/* Species->extragrowth. */
 	 /* HISTORY */
 	/* AT  1st Nov 2015 -Added Species Proportion Grazing for all even for annual */
+	/* 14 August 2018 -CH -Added functionality to graze the species' extra growth. */
 	/*------------------------------------------------------*/
 #define xF_DELTA (20*F_DELTA)
 #define xD_DELTA (20*D_DELTA)
@@ -500,17 +499,23 @@ void Species_Proportion_Grazing(const SppIndex sp, RealF proportionGrazing)
 	
 	//CH- extra growth is only stored at the species level. This will graze extra
 	//    growth for the whole species.
+	//    loss represents the proportion of extragrowth that is eaten by livestock
 	RealF loss = Species[sp]->extragrowth * proportionGrazing;
-	Species[sp]->extragrowth -= loss;
-	Species_Update_Newsize(sp, -loss);	
 
-	IndivType *p = Species[sp]->IndvHead, *t;
-	//do proportional Grazing adjustment for all the species individuals irrespective of being annual or perennial, both will have this effect
-	while (p)
+	//CH- To make sure that _kill_extra_growth() does not remove too much biomass
+	//    I subtracted loss from both extragrowth and Species relsize.
+	//    This way when the extra growth is removed it will have already lost the 
+	//    proportion due to grazing.
+	Species[sp]->extragrowth -= loss;	// remove the loss from extragrowth 
+	Species_Update_Newsize(sp, -loss);	// remove the loss from Species
+
+	//do proportional Grazing adjustment for all the species.
+	IndivType *t, *p = Species[sp]->IndvHead;
+	while (p) //while p points to an individual
 	{
-		t = p->Next;
+		t = p->Next; //must store Next since p might be deleted at any time.
 		indiv_proportion_Grazing(p, proportionGrazing);
-		p = t;
+		p = t; //move to the next plant.
 	}
 
 	if (ZERO(Species[sp]->relsize) || LT(Species[sp]->relsize, 0.0))

--- a/ST_species.c
+++ b/ST_species.c
@@ -497,6 +497,12 @@ void Species_Proportion_Grazing(const SppIndex sp, RealF proportionGrazing)
 		( (sizeof(x) == sizeof(float)) \
 				? ((x)>-xF_DELTA && (x)<xF_DELTA) \
 						: ((x)>-xD_DELTA && (x)<xD_DELTA) )
+	
+	//CH- extra growth is only stored at the species level. This will graze extra
+	//    growth for the whole species.
+	RealF loss = Species[sp]->extragrowth * proportionGrazing;
+	Species[sp]->extragrowth -= loss;
+	Species_Update_Newsize(sp, -loss);	
 
 	IndivType *p = Species[sp]->IndvHead, *t;
 	//do proportional Grazing adjustment for all the species individuals irrespective of being annual or perennial, both will have this effect

--- a/ST_species.c
+++ b/ST_species.c
@@ -484,8 +484,8 @@ void Species_Proportion_Grazing(const SppIndex sp, RealF proportionGrazing)
 
 	/*======================================================*/
 	/* PURPOSE */
-	/* Proportion Grazing on all individuals and on the extra growth stored in
-	/* Species->extragrowth. */
+	/* Proportion Grazing on all individuals and on the extra growth that 
+         * resulted from extra resources this year,stored in Species->extragrowth. */
 	 /* HISTORY */
 	/* AT  1st Nov 2015 -Added Species Proportion Grazing for all even for annual */
 	/* 14 August 2018 -CH -Added functionality to graze the species' extra growth. */
@@ -509,7 +509,7 @@ void Species_Proportion_Grazing(const SppIndex sp, RealF proportionGrazing)
 	Species[sp]->extragrowth -= loss;	// remove the loss from extragrowth 
 	Species_Update_Newsize(sp, -loss);	// remove the loss from Species
 
-	//do proportional Grazing adjustment for all the species.
+	//do proportional grazing adjustment on normal growth for all individuals in each species.
 	IndivType *t, *p = Species[sp]->IndvHead;
 	while (p) //while p points to an individual
 	{

--- a/ST_structs.h
+++ b/ST_structs.h
@@ -59,6 +59,7 @@ struct indiv_st {
        res_extra,    /* resource applied to superficial growth */
        pr,           /* ratio of resources required to amt available */
        growthrate,   /* actual growth rate*/
+       normal_growth, /* Chandler- biomass the plant gained this year, excluding superfluous biomass */
        prob_veggrow; /* set when killed; 0 if not clonal*/
   struct indiv_st *Next, *Prev;  /* facility for linked list 8/3/01 */
 };

--- a/ST_structs.h
+++ b/ST_structs.h
@@ -59,7 +59,7 @@ struct indiv_st {
        res_extra,    /* resource applied to superficial growth */
        pr,           /* ratio of resources required to amt available */
        growthrate,   /* actual growth rate*/
-       normal_growth, /* Chandler- biomass the plant gained this year, excluding superfluous biomass */
+       normal_growth, /* biomass the plant gained this year excluding superfluous biomass. Used for grazing.*/
        prob_veggrow; /* set when killed; 0 if not clonal*/
   struct indiv_st *Next, *Prev;  /* facility for linked list 8/3/01 */
 };


### PR DESCRIPTION
Modified Grazing such that grazing now removes a portion of the plants growth from the current year.
- Added a normal_growth field to the individual struct which represents the non-superfluous biomass the plant gained for the current year.
- Grazing now uses normal growth instead of relative size to calculate how much biomass to remove from each individual.
- Superfluous biomass is subjected to the same grazing proportion and precautions have been taken to ensure that no biomass is subtracted twice when the extra biomass is removed at the end of the year.