### PR TITLE
removed NGroupEstab entirely

### DIFF
--- a/ST_globals.h
+++ b/ST_globals.h
@@ -10,7 +10,7 @@
  *           The main.c module actually declares these
  *           variables. */
 /*  History */
-/*     (6/15/2000) -- INITIAL CODING - cwb */
+/*    (6/15/2000) -- INITIAL CODING - cwb */
 /********************************************************/
 /********************************************************/
 

--- a/ST_params.c
+++ b/ST_params.c
@@ -864,20 +864,6 @@ static void _rgroup_init( void) {
    f = OpenFile(MyFileName, "r");
 
    /* ------------------------------------------------------------*/
-   /* scan for the first line*/
-   if (!GetALine(f, inbuf)) {
-     LogError(logfp, LOGFATAL, "%s: No data found!\n", MyFileName);
-   } else {
-     sscanf( inbuf, "%hd", &Globals.grpMaxEstab);
-     if (Globals.grpMaxEstab < 1   ||
-         Globals.grpMaxEstab > MAX_RGROUPS ) {
-       LogError(logfp, LOGFATAL,"%s: Invalid parameters for RGroupMaxEstab",
-               MyFileName);
-     }
-     GetALine(f,inbuf); /* toss [end] keyword */
-   }
-
-   /* ------------------------------------------------------------*/
    /* Install all the defined groups, except for dry/wet/norm parms */
    groupsok = FALSE;
    while( GetALine(f,inbuf)) {

--- a/ST_structs.h
+++ b/ST_structs.h
@@ -285,8 +285,6 @@ struct globals_st {
       currIter,
       grpCount,     /* number of groups defined*/
       sppCount,     /* number of species defined*/
-      grpMaxEstab,  /* max species groups that can successfully*/
-                    /* establish in a year*/
       transp_window, /* Number of years for which transpiration data is kept*/
       nCells;		/* number of cells to use in Grid, only applicable if grid function is being used */
   IntL randseed;     /* random seed from input file */

--- a/testing.sagebrush.master/Stepwat_Inputs/Input/rgroup.in
+++ b/testing.sagebrush.master/Stepwat_Inputs/Input/rgroup.in
@@ -6,6 +6,7 @@
 # however, the order of input is important
 
 ####################################################
+# All-group parameters:
 # NOTE: only 10 RGs can be established at a time. Below there are 11 RG possibilities. One always has
 # to be turned off. As a default, annual warm-season grasses are turned off.
 #=============================================================

--- a/testing.sagebrush.master/Stepwat_Inputs/Input/rgroup.in
+++ b/testing.sagebrush.master/Stepwat_Inputs/Input/rgroup.in
@@ -6,13 +6,6 @@
 # however, the order of input is important
 
 ####################################################
-# All-group parameters:
-# NGrpEstab = maximum number of resource groups that can
-#        establish in a given year
-#
-# NGrpEstab
-     10
-[end]  # section end
 # NOTE: only 10 RGs can be established at a time. Below there are 11 RG possibilities. One always has
 # to be turned off. As a default, annual warm-season grasses are turned off.
 #=============================================================


### PR DESCRIPTION
There are multiple reasons for removing NGroupEstab:
* It is only used in _rgroup_init(). Its only use is to make sure the user input a value between 1 and 10. The purpose of this is unclear, since MAX_RGROUPS already stores information about the most R groups possible.
* It does not prevent the user from inputting more than 10 R groups. The value of NGroupEstab has no impact on the number of R groups specified in inputs. The user could set NGroupEstab to anything from 2 to 10 and specify anywhere from 0 to 100 R groups. The code would fail while loading R groups, not when checking NGroupEstab.

For these reasons we have chosen to remove NGroupEstab. 