### PR TITLE
Bugfix 512 fnocommon

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "sw_src"]
 	path = sw_src
 	url = https://github.com/DrylandEcology/SOILWAT2.git
-	branch = master
+	branch = feature_nocommon
         ignore = dirty

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "sw_src"]
 	path = sw_src
 	url = https://github.com/DrylandEcology/SOILWAT2.git
-	branch = feature_nocommon
+	branch = master
         ignore = dirty

--- a/ST_environs.c
+++ b/ST_environs.c
@@ -20,10 +20,10 @@
 #include "ST_globals.h"
 #include "sw_src/pcg/pcg_basic.h"
 #include "sw_src/rands.h"
+#include "sxw.h" // externs `*SXW`
 #include "sxw_funcs.h"
 #include "sw_src/filefuncs.h"
 #include "sw_src/Times.h"
-extern SXW_t* SXW;
 
 /*********** Locally Used Function Declarations ************/
 /***********************************************************/
@@ -37,8 +37,7 @@ static void _make_disturbance( void);
 /**************************************************************/
 /**************************************************************/
 
-extern
-  pcg32_random_t environs_rng;
+pcg32_random_t environs_rng;
 
 
 void Env_Generate( void) {

--- a/ST_functions.h
+++ b/ST_functions.h
@@ -17,6 +17,19 @@
 
 #include "ST_defines.h"
 
+
+/* =================================================== */
+/*            Externed Global Variables                */
+/* --------------------------------------------------- */
+extern pcg32_random_t environs_rng; // defined in ST_environs.c
+extern pcg32_random_t resgroups_rng; // defined in  ST_resgroups.c
+extern pcg32_random_t species_rng; // defined in ST_species.c
+
+
+
+/* =================================================== */
+/*             Global Function Declarations            */
+/* --------------------------------------------------- */
 void Env_Generate( void );
 void copy_environment(const EnvType* src, EnvType* dest);
 void copy_plot(const PlotType* src, PlotType* dest);

--- a/ST_globals.h
+++ b/ST_globals.h
@@ -30,3 +30,4 @@ extern MortFlagsType  MortFlags;
 extern GlobalType     SuperGlobals;
 
 extern Bool UseGrid;
+extern Bool UseProgressBar;

--- a/ST_grid.h
+++ b/ST_grid.h
@@ -25,7 +25,7 @@
 /*********************** Grid Structures ****************************/
 
 // Contains the input data for all the soil layers of a cell
-struct Soil_st
+typedef struct Soil_st
 {
 	// Number of soil layers (size of lyr array)
 	int num_layers;
@@ -45,20 +45,20 @@ struct Soil_st
     RealF *pclay;       /* Each Layer's clay content */
     RealF *imperm;      /* Each layer's impermiability */
     RealF *soiltemp;    /* Each Layer's temperature */
-}typedef SoilType;
+} SoilType;
 
 /* Initialization information. */
-struct grid_init_species_st
+typedef struct grid_init_species_st
 {
 	/* TRUE if at least one species has requested initialization */
 	int useInitialization;
 	/* Array of Boolean values. TRUE if given species
 	   should be included in spinup */
 	int *shouldBeInitialized;
-}typedef Grid_Init_Species_St;
+} Grid_Init_Species_St;
 
 /* Holds all plot-specific parameters */
-struct grid_cell_st
+typedef struct grid_cell_st
 {
 	/* RGroup corresponding to this cell */
 	GroupType **myGroup;
@@ -108,7 +108,7 @@ struct grid_cell_st
 	// Soil layer information for this cell.
 	SoilType mySoils;
 	/* ------------------ End Soils --------------------- */
-} typedef CellType;
+}  CellType;
 
 /**************************** Enumerators *********************************/
 /* Indices for grid_directories go here */

--- a/ST_grid.h
+++ b/ST_grid.h
@@ -147,20 +147,20 @@ typedef enum
 	SOIL_READ_FAILURE = -1,
 } Soil_Read_Return_Values;
 
-/************************ Exported Variable Declarations **************************/
 
-/* gridCells[i][j] denotes the cell at position (i,j) */
-CellType** gridCells;
-/* Rows in the grid */
-int grid_Rows;
-/* Columns in the grid */
-int grid_Cols;
-/* Array of file names. Use the File_Indices enum to pick the correct index. */
-char *grid_files[N_GRID_FILES];
-/* Array of directory names. Use the Directory_Indices enum to pick the correct index. */
-char *grid_directories[N_GRID_DIRECTORIES];
-/* TRUE if every cell should write its own output file. */
-Bool writeIndividualFiles;
+
+/* =================================================== */
+/*            Externed Global Variables                */
+/* --------------------------------------------------- */
+extern pcg32_random_t grid_rng;
+extern CellType** gridCells;
+extern int grid_Rows;
+extern int grid_Cols;
+extern char *grid_files[N_GRID_FILES];
+extern char *grid_directories[N_GRID_DIRECTORIES];
+extern Bool writeIndividualFiles;
+
+
 
 /**************************** Exported Functions **********************************/
 

--- a/ST_initialization.h
+++ b/ST_initialization.h
@@ -29,13 +29,12 @@ void runInitialization(void);
 void loadInitializationConditions(void);
 void freeInitializationMemory(void);
 
-/************************ Exported variables ****************************/
 
-/* Stores the state of the cells following spinup. */
-CellType** initializationCells;
-/* The method of initialization specified in inputs. */
-InitializationMethod initializationMethod;
-/* TRUE if the program is currently in initialization. */
-Bool DuringInitialization;
+/* =================================================== */
+/*            Externed Global Variables                */
+/* --------------------------------------------------- */
+extern CellType** initializationCells;
+extern InitializationMethod initializationMethod;
+extern Bool DuringInitialization;
 
 #endif

--- a/ST_mortality.c
+++ b/ST_mortality.c
@@ -34,6 +34,34 @@
 #include "sw_src/pcg/pcg_basic.h"
 #include "sxw_vars.h"
 
+
+/* =================================================== */
+/*                  Global Variables                   */
+/* --------------------------------------------------- */
+
+/* ----------------------------- Exported RNG ------------------------------ */
+
+/**
+ * \brief The random number generator specific to the
+ *        [mortality](\ref MORTALITY) module.
+ *
+ * This RGN is declared in the header file for other modules can seed it. Other
+ * modules should NOT use this RNG to generate random numbers.
+ *
+ * \ingroup MORTALITY
+ */
+pcg32_random_t mortality_rng;
+
+/* ---------------------------- Exported Flags ----------------------------- */
+
+/**
+ * \brief A flag for turning cheatgrass-driven wildfire on and off.
+ * \ingroup MORTALITY
+ */
+Bool UseCheatgrassWildfire = 0;
+
+
+
 /******** Modular External Function Declarations ***********/
 /* -- truly global functions are declared in functions.h --*/
 /***********************************************************/

--- a/ST_mortality.h
+++ b/ST_mortality.h
@@ -94,44 +94,31 @@ void initCheatgrassPrecip(void);
 void setCheatgrassPrecip(CheatgrassPrecip* newCheatgrassPrecip);
 CheatgrassPrecip* getCheatgrassPrecip(void);
 
-/* ----------------------------- Exported RNG ------------------------------ */
-
-/**
- * \brief The random number generator specific to the 
- *        [mortality](\ref MORTALITY) module.
- * 
- * This RGN is declared in the header file for other modules can seed it. Other
- * modules should NOT use this RNG to generate random numbers.
- * 
- * \ingroup MORTALITY
- */
-pcg32_random_t mortality_rng;
-
-/* ---------------------------- Exported Flags ----------------------------- */
-
-/**
- * \brief A flag for turning cheatgrass-driven wildfire on and off.
- * \ingroup MORTALITY
- */
-Bool UseCheatgrassWildfire;
-
 /* ---------------------------- Exported Enums ----------------------------- */
 
 /**
  * \brief All types of mortality.
- * 
+ *
  * Used to record what killed an individual.
- * 
+ *
  * \sa indiv_st which instantiates this enumerator.
- * 
+ *
  * \ingroup MORTALITY
  */
 typedef enum {
-    Slow, 
-    NoResources, 
-    Intrinsic, 
-    Disturbance, 
+    Slow,
+    NoResources,
+    Intrinsic,
+    Disturbance,
     LastMort
 } MortalityType;
+
+
+/* =================================================== */
+/*            Externed Global Variables                */
+/* --------------------------------------------------- */
+extern pcg32_random_t mortality_rng;
+extern Bool *_SomeKillage;
+extern Bool UseCheatgrassWildfire;
 
 #endif

--- a/ST_mortality.h
+++ b/ST_mortality.h
@@ -31,7 +31,7 @@
  * \date 13 January 2020
  * \ingroup MORTALITY
  */
-struct CheatgrassPrecip_st {
+typedef struct CheatgrassPrecip_st {
   /** \brief The Spring precipitation in the previous 3 years.
    * The array is indexed from newest to oldest, meaning prevSpring[0] is the 
    * most recent value. */
@@ -75,7 +75,7 @@ struct CheatgrassPrecip_st {
    * even though it does make the struct a little more confusing. 
    */ 
   double thisJanThruMar;
-} typedef CheatgrassPrecip;
+} CheatgrassPrecip;
 
 /* -------------------------- Exported Functions --------------------------- */
 // See ST_mortality.c for definitions and documentation of these functions.

--- a/ST_output.c
+++ b/ST_output.c
@@ -23,8 +23,8 @@
 /******** Modular External Function Declarations ***********/
 /* -- truly global functions are declared in functions.h --*/
 /***********************************************************/
-#include "sw_src/SW_Model.h"
-extern SW_MODEL SW_Model;
+#include "sw_src/SW_Model.h" // externs `SW_Model`
+
 
 /*------------------------------------------------------*/
 /* Modular functions only used on one or two specific   */

--- a/ST_params.c
+++ b/ST_params.c
@@ -34,6 +34,8 @@
 /***********************************************************/
 #include "ST_globals.h"
 #include "sxw_vars.h"
+#include "ST_mortality.h" // externs `UseCheatgrassWildfire`
+
 
 /******** Modular External Function Declarations ***********/
 /* -- truly global functions are declared in functions.h --*/

--- a/ST_resgroups.c
+++ b/ST_resgroups.c
@@ -37,8 +37,12 @@
 #include "ST_functions.h"
 #include "sxw_funcs.h"
 
-extern
-  pcg32_random_t resgroups_rng;
+
+/* =================================================== */
+/*                  Global Variables                   */
+/* --------------------------------------------------- */
+pcg32_random_t resgroups_rng;
+
 
 /******** Modular External Function Declarations ***********/
 /* -- truly global functions are declared in functions.h --*/

--- a/ST_seedDispersal.c
+++ b/ST_seedDispersal.c
@@ -15,12 +15,22 @@ int _do_bulk_dispersal(SppIndex sp);
 void _do_precise_dispersal(int leftoverSeeds, SppIndex sp);
 float _cell_dist(int row1, int row2, int col1, int col2, float cellLen);
 
+
+/* =================================================== */
+/*                  Global Variables                   */
+/* --------------------------------------------------- */
+
 /* RNG unique to seed dispersal. */
 pcg32_random_t dispersal_rng;
 
-/* Derives the probabilities that a given cell will disperse seeds to any other cell. 
-   results of this function can be accessed using 
-   gridCells[a][b].mySeedDispersal[s].dispersalProb[c][d] 
+/* TRUE if we should run seed dispersal between years during the main simulation. */
+Bool UseSeedDispersal = 0;
+
+
+
+/* Derives the probabilities that a given cell will disperse seeds to any other cell.
+   results of this function can be accessed using
+   gridCells[a][b].mySeedDispersal[s].dispersalProb[c][d]
    where (a,b) are the coordinates of the sender,
    (b, c) are the coordinates of the receiver,
    and s is the species. */

--- a/ST_seedDispersal.h
+++ b/ST_seedDispersal.h
@@ -10,7 +10,7 @@
 #define SEEDDISPERSAL_H
 
 /* Holds seed dispersal information. */
-struct _grid_sd_struct
+typedef struct _grid_sd_struct
 { //for seed dispersal
 	/* TRUE if seeds are present. */
 	Bool seeds_present;
@@ -20,7 +20,7 @@ struct _grid_sd_struct
 	double **dispersalProb;
 	/* Last year's precipitation. */
 	double lyppt;
-}typedef Grid_SD_St;
+} Grid_SD_St;
 
 /* TRUE if we should run seed dispersal between years during the main simulation. */
 Bool UseSeedDispersal;

--- a/ST_seedDispersal.h
+++ b/ST_seedDispersal.h
@@ -22,9 +22,16 @@ typedef struct _grid_sd_struct
 	double lyppt;
 } Grid_SD_St;
 
-/* TRUE if we should run seed dispersal between years during the main simulation. */
-Bool UseSeedDispersal;
 
+/* =================================================== */
+/*            Externed Global Variables                */
+/* --------------------------------------------------- */
+extern Bool UseSeedDispersal;
+
+
+/* =================================================== */
+/*             Global Function Declarations            */
+/* --------------------------------------------------- */
 void disperseSeeds(void);
 void initDispersalParameters(void);
 

--- a/ST_species.c
+++ b/ST_species.c
@@ -29,10 +29,15 @@
 #include "sw_src/rands.h"
 #include "sw_src/pcg/pcg_basic.h"
 #include "ST_initialization.h"
-#include "ST_seedDispersal.h"
+#include "ST_seedDispersal.h" // externs `UseSeedDispersal`
 
-extern
-  pcg32_random_t species_rng;
+
+/* =================================================== */
+/*                  Global Variables                   */
+/* --------------------------------------------------- */
+pcg32_random_t species_rng;
+
+
 
 /******** Modular External Function Declarations ***********/
 /* -- truly global functions are declared in functions.h --*/

--- a/ST_stats.c
+++ b/ST_stats.c
@@ -39,7 +39,7 @@
 #include "sw_src/myMemory.h"
 #include "ST_structs.h"
 #include "ST_stats.h" // Contains most of the function declarations.
-#include "ST_seedDispersal.h"
+#include "ST_seedDispersal.h" // externs `UseSeedDispersal`
 #include "ST_globals.h"
 
 /* ----------------- Local Variables --------------------- */

--- a/ST_stats.h
+++ b/ST_stats.h
@@ -23,16 +23,16 @@ struct accumulators_st {
 };
 
 /* Accumulator along with the RGroup or Species name. */
-struct stat_st {
+typedef struct stat_st {
   char *name; /* array of ptrs to names in RGroup & Species */
   struct accumulators_st *s;
-} typedef StatType;
+} StatType;
 
 /* Struct for wildfire and prescribed fire stats. */
-struct fire_st {
+typedef struct fire_st {
   int *wildfire;
   int **prescribedFire;
-} typedef FireStatsType;
+} FireStatsType;
 
 /*----------------------- Exported Functions ---------------------------------- */
 void stat_Collect( Int year ) ;

--- a/sxw.c
+++ b/sxw.c
@@ -45,8 +45,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include "sw_src/generic.h"
-#include "sw_src/filefuncs.h"
+#include "sw_src/generic.h" // externs `errstr`
+#include "sw_src/filefuncs.h" // externs `inbuf`
 #include "sw_src/myMemory.h"
 #include "ST_steppe.h"
 #include "ST_globals.h"
@@ -63,7 +63,7 @@
 #include "sw_src/SW_Files.h"
 #include "sw_src/SW_Weather.h"
 #include "sw_src/SW_Markov.h"
-#include "sw_src/SW_Output.h"
+#include "sw_src/SW_Output.h" // externs `prepare_IterationSummary`, `storeAllIterations`
 #include "sw_src/rands.h"
 #include "sw_src/pcg/pcg_basic.h"
 
@@ -71,17 +71,10 @@
 /*************** Global Variable Declarations ***************/
 /***********************************************************/
 SXW_t* SXW;
+SXW_resourceType* SXWResources;
+pcg32_random_t resource_rng; //rng for swx_resource.c functions.
 
-extern SW_SITE SW_Site;
-extern SW_MODEL SW_Model;
-extern SW_VEGPROD SW_VegProd;
-extern SW_WEATHER SW_Weather;
-extern SW_MARKOV SW_Markov;
-//extern SW_SOILWAT SW_Soilwat;
 
-// defined in `SW_Output.c`:
-extern Bool prepare_IterationSummary;
-extern Bool storeAllIterations;
 
 /*************** Module/Local Variable Declarations ***************/
 /***********************************************************/
@@ -91,11 +84,8 @@ extern Bool storeAllIterations;
 // Window of transpiration used by _transp_contribution_by_group() in sxw_resource.c
 // "Window" refers to the number of years over which transpiration data is averaged.
 transp_t* transp_window;
-pcg32_random_t resource_rng; //rng for swx_resource.c functions.
-SXW_resourceType* SXWResources;
 
 /* These are only used here so they are static.  */
-// static char inbuf[FILENAME_MAX];   /* reusable input buffer */
 static char _swOutDefName[FILENAME_MAX];
 static char *MyFileName;
 static char **_sxwfiles[SXW_NFILES];

--- a/sxw.h
+++ b/sxw.h
@@ -32,7 +32,7 @@
 int getNTranspLayers(int veg_prod_type);
 void free_all_sxw_memory( void );
 
-struct stepwat_st {
+typedef struct stepwat_st {
   // ------ Values from SOILWAT2:
   // Note: the function `SW_OUT_set_SXWrequests` specifies the required
   // output time periods and output aggregation types
@@ -67,7 +67,7 @@ struct stepwat_st {
 
   // ------ DEBUG stuff:
   char *debugfile; /* added in ST_Main(), read to get debug instructions */
-} typedef SXW_t;
+} SXW_t;
 
 /** 
  * \brief Stores statistics on transpiration over a window defined in inputs.
@@ -80,7 +80,7 @@ struct stepwat_st {
  * 
  * \ingroup SXW
  */
-struct transp_data {
+typedef struct transp_data {
   // average of all transp/ppt values currently inside ratios[]. It should be updated every time
   // a value is added to transp[].
   RealF ratio_average;
@@ -123,10 +123,10 @@ struct transp_data {
   // this variable keeps track of what year last year was, to make sure that the year actually
   // incremented. If it did NOT, then this is a setup year.
   int lastYear;
-  
-} typedef transp_t;
 
-struct temp_SXW_st{
+} transp_t;
+
+typedef struct temp_SXW_st{
   /* ----- 3d arrays ------- */
   RealD * _rootsXphen, /* relative roots X phen in each lyr,grp,pd */
         * _roots_active, // "active" in terms of size and phenology 
@@ -153,7 +153,7 @@ struct temp_SXW_st{
   RealD* _prod_bmass;
   RealD* _prod_pctlive;
 
-} typedef SXW_resourceType;
+} SXW_resourceType;
 
 #define ForEachTrPeriod(i) for((i)=0; (i)< SXW->NPds; (i)++)
 

--- a/sxw.h
+++ b/sxw.h
@@ -28,6 +28,9 @@
 #include "sw_src/SW_Times.h"
 #include "ST_defines.h"
 #include "sw_src/SW_Defines.h"
+#include "sw_src/pcg/pcg_basic.h"
+
+
 
 int getNTranspLayers(int veg_prod_type);
 void free_all_sxw_memory( void );
@@ -180,5 +183,15 @@ typedef struct temp_SXW_st{
 /* convert 2d group by layer indices to
    layer/period 1D index */
 #define Ilg(l,g) ((l)*SXW->NGrps + (g))
+
+
+
+/* =================================================== */
+/*            Externed Global Variables                */
+/* --------------------------------------------------- */
+extern SXW_t *SXW;
+extern SXW_resourceType *SXWResources;
+extern pcg32_random_t resource_rng;
+extern transp_t *transp_window;
 
 #endif

--- a/sxw_environs.c
+++ b/sxw_environs.c
@@ -19,25 +19,16 @@
 #include <stdio.h>
 #include "sw_src/generic.h"
 #include "ST_steppe.h"
-/*#include "ST_globals.h"*/
+#include "ST_globals.h" // externs `*Env`
 #include "sw_src/SW_Defines.h"
-#include "sxw.h"
+#include "sxw.h" // externs `*SXW`
 #include "sxw_module.h"
-#include "sw_src/SW_Model.h"
-#include "sw_src/SW_Site.h"
-#include "sw_src/SW_SoilWater.h"
-#include "sw_src/SW_Weather.h"
+#include "sw_src/SW_Model.h" // externs SW_Model
+#include "sw_src/SW_Site.h" // externs SW_Site
+#include "sw_src/SW_SoilWater.h" // externs SW_Soilwat
+#include "sw_src/SW_Weather.h" // externs SW_Weather
 
-/*************** Global Variable Declarations ***************/
-/***********************************************************/
-extern SXW_t* SXW;
 
-extern SW_SITE SW_Site;
-extern SW_MODEL SW_Model;
-extern SW_SOILWAT SW_Soilwat;
-extern SW_WEATHER SW_Weather;
-
-extern EnvType *Env;
 
 /*************** Local Variable Declarations ***************/
 /***********************************************************/

--- a/sxw_main.c
+++ b/sxw_main.c
@@ -27,8 +27,8 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include "ST_steppe.h"
-#include "sw_src/generic.h"
-#include "sw_src/filefuncs.h"
+#include "sw_src/generic.h" // externs `errstr`
+#include "sw_src/filefuncs.h" // externs `inbuf`
 #include "sw_src/myMemory.h"
 #include "sxw_funcs.h"
 
@@ -43,10 +43,7 @@
 /************ External Variable Definitions  ***************/
 /*              see ST_globals.h                       */
 /***********************************************************/
-char errstr[1024];
-char inbuf[1024];
-FILE *logfp;
-int logged;  /* indicator that err file was written to */
+
 SpeciesType  **Species;
 GroupType    **RGroup;
 SucculentType  Succulent;

--- a/sxw_resource.c
+++ b/sxw_resource.c
@@ -28,7 +28,7 @@
 #include "ST_steppe.h"
 #include "ST_globals.h"
 #include "sw_src/SW_Defines.h"
-#include "sxw.h"
+#include "sxw.h" // externs `*SXWResources`, `transp_window`, `resource_rng`
 #include "sxw_module.h"
 #include "sxw_vars.h"
 #include "sw_src/SW_Control.h"
@@ -39,22 +39,11 @@
 #include "sw_src/SW_Times.h"
 #include "sw_src/pcg/pcg_basic.h"
 
+
+
 /*************** Global Variable Declarations ***************/
 /***********************************************************/
 /* for steppe, see ST_globals.h */
-
-//extern SW_SITE SW_Site;
-//extern SW_SOILWAT SW_Soilwat;
-//extern SW_VEGPROD SW_VegProd;
-
-extern SXW_resourceType* SXWResources;
-
-/* ------ Running Averages ------ */
-extern
-  transp_t* transp_window;
-
-extern
-  pcg32_random_t resource_rng;
 
 //void _print_debuginfo(void);
 

--- a/sxw_soilwat.c
+++ b/sxw_soilwat.c
@@ -43,24 +43,17 @@
 #include "ST_steppe.h"
 #include "ST_globals.h"
 #include "sw_src/SW_Defines.h"
-#include "sxw.h"
+#include "sxw.h" // externs `*SXWResources`
 #include "sxw_module.h"
+#include "sxw_vars.h"
 #include "sw_src/SW_Control.h"
-#include "sw_src/SW_Model.h"
-#include "sw_src/SW_Site.h"
+#include "sw_src/SW_Model.h" // externs `SW_Model`
+#include "sw_src/SW_Site.h" // externs `SW_Site`
 #include "sw_src/SW_SoilWater.h"
-#include "sw_src/SW_VegProd.h"
+#include "sw_src/SW_VegProd.h" // externs `SW_VegProd`
 #include "sw_src/SW_Files.h"
 
 
-/*************** Global Variable Declarations ***************/
-/***********************************************************/
-#include "sxw_vars.h"
-
-extern SW_SITE SW_Site;
-extern SW_MODEL SW_Model;
-extern SW_VEGPROD SW_VegProd;
-extern SXW_resourceType* SXWResources;
 
 /*************** Local Function Declarations ***************/
 /***********************************************************/

--- a/sxw_sql.c
+++ b/sxw_sql.c
@@ -11,14 +11,12 @@
 #include "ST_steppe.h"
 #include "ST_globals.h"
 #include "sw_src/SW_Defines.h"
+#include "sw_src/SW_Model.h" // externs `SW_Model`
+#include "sw_src/SW_Site.h" // externs `SW_Site`
+#include "sw_src/SW_VegProd.h" // externs `SW_VegProd`
 #include "sxw_module.h"
-#include "sxw.h"
+#include "sxw.h" // externs `*SXW`, `*SXWResources`
 
-extern SW_MODEL SW_Model;
-extern SXW_t* SXW;
-extern SW_SITE SW_Site;
-extern SW_VEGPROD SW_VegProd;
-extern SXW_resourceType* SXWResources;
 
 static sqlite3 *db;
 static char sql[1024];

--- a/sxw_vars.h
+++ b/sxw_vars.h
@@ -15,11 +15,9 @@
 #ifndef SXW_VARS_DEF
 #define SXW_VARS_DEF
 
-#include "sxw.h"
+#include "sxw.h" // externs `*SXW`
 #include "sw_src/generic.h"
 
-
-extern SXW_t* SXW;
 
 
 #endif


### PR DESCRIPTION
 Updated approach for global variables

- close #512

- previously, defined/implemented global variables in one source file & used extern declaration by each other source files that referenced a global variable
--> problem: repeated declarations

- previously, some header files defined/implemented global variables including ST_grid.h, ST_initialization.h, and ST_seedDispersal.h
 --> error due to `-fno-common` compilation as described in #512

- new approach (https://stackoverflow.com/questions/1433204/how-do-i-use-extern-to-share-variables-between-source-files?rq=1):
* define/implement global variables in one source file
* extern declare these variables in the header file belonging to that source file
* include the header file by each other source files that referenced a global variable

--> reflecting corresponding SOILWAT2 changes, see DrylandEcology/SOILWAT2#289

--> no changes to example output