### PR TITLE
README: suggestions on how to compare output between versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,12 +60,17 @@ testing/stepwat
 testing/valgrind.out
 testing/stepwat.dSYM/
 
+
 testing.sagebrush.MT_drs/Stepwat_Inputs/Input/sxw/Input/outsetup_v30.in
 *.out
 *.log
 
-*/Output
-*/Stepwat_Inputs/Output
+*/Output*
+*/Stepwat_Inputs/Output*
+
+# Reference files (used for comparisons against devel branches)
+Input_*
+Fig_*
 
 # Netbeans project files
 #######################

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ cd testing.sagebrush.master/Stepwat_Inputs/
 
 
 * Run non-gridded version of STEPWAT using SOILWAT and output all variables passed between Stepwat and SOILWAT:
-  
+
 ```
 cd testing.sagebrush.master/Stepwat_Inputs/
 ./stepwat -f files.in -ssxwdebug.in
@@ -131,6 +131,37 @@ git checkout -b [branch name]
 ```
 git submodule update --init --recursive
 ```
+
+
+<br>
+
+## Compare output of a new branch to output from a previous (reference) release
+
+Depending on the purpose of the development branch
+the new output should be exactly the same as reference output or
+differ in specific ways in specific variables.
+
+The following steps provide a starting point for such comparisons:
+
+```
+# Simulate on master branch and copy output to "Output_ref"
+git checkout master
+make clean bint_testing_nongridded
+cp -r testing.sagebrush.master/Stepwat_Inputs/Output testing.sagebrush.master/Stepwat_Inputs/Output_ref
+
+# Switch to development branch <branch_xxx> and run the same simulation
+git checkout <branch_xxx>
+make clean bint_testing_nongridded
+
+# Compare the two sets of outputs
+#   * Lists all output files and determine if they are exactly they same
+diff -qsr testing.sagebrush.master/Stepwat_Inputs/Output testing.sagebrush.master/Stepwat_Inputs/Output_ref
+#   * Produce two figures (scatter plots and time series of biomass)
+#     that are saved as PDFs at testing.sagebrush.master/
+Rscript tools/compare_bmassavg_against_ref.R
+```
+
+
 
 <br>
 

--- a/tools/compare_bmassavg_against_ref.R
+++ b/tools/compare_bmassavg_against_ref.R
@@ -8,10 +8,17 @@
 
 # Run this R code from within the directory of `STEPWAT2/` after
 # two non-gridded `STEPWAT2` simulations have been run in the testing directory
+# ```
 #   cd testing.sagebrush.master/Stepwat_Inputs/
 #   ./stepwat -f files.in -o
 #   cp -r Output/ Output_ref/
+#
+#   # Switch to development branch
 #   ./stepwat -f files.in -o
+#   cd ../..
+#
+#   Rscript tools/compare_bmassavg_against_ref.R
+# ```
 
 #-------------------------------------------
 

--- a/tools/test_SOILWAT2_csvfiles.R
+++ b/tools/test_SOILWAT2_csvfiles.R
@@ -8,21 +8,30 @@
 # Consider turning on csv-output files for each of the four output time periods:
 # --> set `TIMESTEP dy wk mo yr` in file `outsetup.in`
 
-# Run this R code from the parent directory of `STEPWAT2/` after a
-# `STEPWAT2` sumulation has been run in the testing directory with
+# Run this R code from within the `STEPWAT2/` directory after a
+# `STEPWAT2` simulation has been run in the testing directory with
+# ```
 #   cd testing.sagebrush.master/Stepwat_Inputs/
 #   ./stepwat -f files.in -s -i -o
+#   cd ../..
+#   Rscript tools/test_SOILWAT2_csvfiles.R
+# ```
 
 # Adjust variable `reps` below to reflect number of iterations from `STEPWAT2`
 # run (as specified as `niter` in file `model.in`).
 #-------------------------------------------
 
-dir <- "STEPWAT2/testing.sagebrush.master/Stepwat_Inputs/Output/sw_output"
+dir <- file.path(
+  "testing.sagebrush.master",
+  "Stepwat_Inputs",
+  "Output",
+  "sw_output"
+)
 
 report_by_var <- FALSE
 report_by_period <- TRUE
 
-reps <- 3
+reps <- 1
 OutPeriods <- c("daily", "weekly", "monthly", "yearly")
 agg_type <- c("", "_slyrs")
 


### PR DESCRIPTION
This PR adds a section to `README` with suggestions on how to use available tools to compare output of a new branch to output from a previous (reference) release

Depending on the purpose of the development branch
the new output should be exactly the same as some reference output or
differ in specific ways for specific variables.