### PR TITLE
Reproducibly set random number generators

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "sw_src"]
 	path = sw_src
 	url = https://github.com/DrylandEcology/SOILWAT2.git
-	branch = master
+	branch = feature_pcg_seeding
         ignore = dirty

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "sw_src"]
 	path = sw_src
 	url = https://github.com/DrylandEcology/SOILWAT2.git
-	branch = feature_pcg_seeding
+	branch = master
         ignore = dirty

--- a/ST_defines.h
+++ b/ST_defines.h
@@ -35,6 +35,33 @@
 /***************************************************
  * Basic definitions
  ***************************************************/
+
+/**
+ * \brief Random number generators sequence spacing
+          among iterations, years, and grid cells
+*/
+#define RNG_SEQDELTA1 1000000000000UL // must be larger than `MAX_ITERATIONS * MAX_YEARS * MAX_CELLS`
+
+/**
+ * \brief Random number generators sequence spacing among years and grid cells
+*/
+#define RNG_SEQDELTA2 100000000UL // must be larger than `MAX_YEARS * MAX_CELLS`
+
+/**
+ * \brief Macro for initial RNG sequence identifiers
+ *
+ * RNGs are seeded with an initial state and initial sequence identifier that is
+ * reproducible and unique among RNGs.
+ * Some RNGs are unique among iterations and years but each grid cell produces
+ * an identical stream (e.g., weather generator),
+ * i.e., their initial sequence is determined by
+ *   `rng_id * RNG_SEQDELTA + iteration`.
+ * Some RNGs are unique among iterations, years, and grid cells
+ * (e.g., plant dynamics), i.e., their initial sequence is determined by
+ *   `rng_id * RNG_SEQDELTA + iteration * MAX_CELLS + cell_id`.
+ */
+#define RNG_INITSEQ(rng_id, iter, year, cell_id) ((unsigned long) (rng_id) * RNG_SEQDELTA1 + (iter) * RNG_SEQDELTA2 + (year) * MAX_CELLS + (cell_id))
+
 /**
  * \brief Macro for the maximum number of species allowed in the simulation.
  * 

--- a/ST_functions.h
+++ b/ST_functions.h
@@ -34,6 +34,7 @@ void Env_Generate( void );
 void copy_environment(const EnvType* src, EnvType* dest);
 void copy_plot(const PlotType* src, PlotType* dest);
 void copy_succulent(const SucculentType* src, SucculentType* dest);
+void set_all_rngs(unsigned long initstate, int iter, int year, int cell_id);
 
 /* See steppe_main.c for declarations of the following
 

--- a/ST_grid.c
+++ b/ST_grid.c
@@ -214,13 +214,6 @@ void runGrid(void)
 			loadInitializationConditions();
 		}
 
-		RandSeed(SuperGlobals.randseed, &environs_rng);
-		RandSeed(SuperGlobals.randseed, &mortality_rng);
-		RandSeed(SuperGlobals.randseed, &resgroups_rng);
-		RandSeed(SuperGlobals.randseed, &species_rng);
-		RandSeed(SuperGlobals.randseed, &grid_rng);
-		RandSeed(SuperGlobals.randseed, &markov_rng);
-
 		for (year = 1; year <= SuperGlobals.runModelYears; year++)
 		{ //for each year
 			if(UseProgressBar){
@@ -232,6 +225,8 @@ void runGrid(void)
                 
                     /* Ensure that all global variables reference the specific cell */
 					load_cell(i, j);
+
+					set_all_rngs(SuperGlobals.randseed, iter, year, j * grid_Rows + i);
 
 					Globals->currYear = year;
 

--- a/ST_grid.c
+++ b/ST_grid.c
@@ -50,6 +50,11 @@
 #include "ST_mortality.h" // externs `mortality_rng`, `*_SomeKillage`, `UseCheatgrassWildfire`
 
 
+#include "sw_src/SW_Flow.h" // for `SW_FLW_init_run()`
+#include "sw_src/SW_Flow_lib.h" // for `SW_ST_init_run()`
+
+
+
 /* =================================================== */
 /*                  Global Variables                   */
 /* --------------------------------------------------- */
@@ -808,6 +813,24 @@ void load_cell(int row, int col){
 					   gridCells[row][col].mySoils.psand, gridCells[row][col].mySoils.pclay, gridCells[row][col].mySoils.imperm,
 				   	   gridCells[row][col].mySoils.soiltemp, 3, soilRegionsLowerBounds);
 	}
+
+	// Zero SOILWAT2 variables (weather, flow, soil temperature, soil moisture)
+	// of current cell; otherwise, last values from previous cell carry over
+	// to first value of next cell (vegetation is handled separately by STEPWAT2).
+	// NOTE: This should also reset soil variables via `SW_SIT_init_run()` but
+	// soils are here handled separately via the previous section calling
+	// `set_soillayers()`.
+	// NOTE: To fully re-initialize all SOILWAT2 variables, this here
+	// should be a call to `SW_CTL_init_run()`.
+	// WARNING: Ideally, a grid cell should continue with the state that it ended
+	// the previous year (and not be zeroed out).
+	// FIXME: remove once SOILWAT2 is re-entrant or
+	// gridded code manages SOILWAT2 globals.
+	SW_WTH_init_run();
+	//SW_SIT_init_run();
+	SW_FLW_init_run();
+	SW_ST_init_run();
+	SW_SWC_init_run();
 }
 
 /* Nullify all global variables. This function should appear after every call 

--- a/ST_initialization.c
+++ b/ST_initialization.c
@@ -92,14 +92,6 @@ void runInitialization(void){
 	/* For iterating over years */
 	IntS year;
 
-    /* Initialization is technically an iteration so we need to seed the RNGs. */
-    RandSeed(SuperGlobals.randseed, &environs_rng);
-    RandSeed(SuperGlobals.randseed, &mortality_rng);
-    RandSeed(SuperGlobals.randseed, &resgroups_rng);
-    RandSeed(SuperGlobals.randseed, &species_rng);
-    RandSeed(SuperGlobals.randseed, &grid_rng);
-    RandSeed(SuperGlobals.randseed, &markov_rng);
-
     // Initialize the plot for each grid cell
     for (i = 0; i < grid_Rows; i++){
         for (j = 0; j < grid_Cols; j++){
@@ -127,6 +119,8 @@ void runInitialization(void){
                 } else {
                     continue; // No spinup requested. Move on to next cell.
                 }
+
+                set_all_rngs(SuperGlobals.randseed, 0, year, j * grid_Rows + i);
 
                 /* This step is important. load_cell loaded in the actual accumulators, but we do not want
                     to accumulate stats while in spinup. We need to load in dummy accumulators to ensure

--- a/ST_seedDispersal.c
+++ b/ST_seedDispersal.c
@@ -44,7 +44,9 @@ void initDispersalParameters(void)
 	double distanceBetweenPlots; /* distance between the sender and the receiver */
     CellType* sender;
 
-    RandSeed(SuperGlobals.randseed, &dispersal_rng);
+	// FIXME: seed with appropriate iter, year, and cell_id
+	// RNG ID 6, see `set_all_rngs()`
+	RandSeed(SuperGlobals.randseed, RNG_INITSEQ(6, 0, 0, 0), &dispersal_rng);
 
 	/* sender denotes that these loops refer to the cell distributing seeds */
 	for(senderRow = 0; senderCol < grid_Rows; ++senderRow){

--- a/ST_seedDispersal.h
+++ b/ST_seedDispersal.h
@@ -27,7 +27,7 @@ typedef struct _grid_sd_struct
 /*            Externed Global Variables                */
 /* --------------------------------------------------- */
 extern Bool UseSeedDispersal;
-
+extern pcg32_random_t dispersal_rng;
 
 /* =================================================== */
 /*             Global Function Declarations            */

--- a/sxw.c
+++ b/sxw.c
@@ -141,7 +141,9 @@ void SXW_Init( Bool init_SW, char *f_roots ) {
    */
 	char roots[MAX_FILENAMESIZE] = { '\0' };
 
-	RandSeed(SuperGlobals.randseed, &resource_rng);
+	// FIXME: seed with appropriate iter, year, and cell_id
+	// RNG ID 7, see `set_all_rngs()`
+	RandSeed(SuperGlobals.randseed, RNG_INITSEQ(7, 0, 0, 0), &resource_rng);
 
 	_allocate_memory(); //Allocate memory for all local pointers
 

--- a/testing.sagebrush.master/Stepwat_Inputs/Input/sxw/Input/weathsetup.in
+++ b/testing.sagebrush.master/Stepwat_Inputs/Input/sxw/Input/weathsetup.in
@@ -1,15 +1,25 @@
-# Weather setup parameters
-#
-1			# 1 = simulate snow processes; 0 = no snow effects
-0.0			# % of snow drift per snow event (+ indicates snow addition, - indicates snow taken away from site)
-0.0			# % of snowmelt water as runoff/on per event (>0 indicates runoff, <0 indicates runon)
+#------ Input file for weather-related parameters and weather generator settings
+
+#--- Activate/deactivate simulation of snow-related processes
+1			# 1 = do/don't simulate snow processes
+0.0			# snow drift/blowing snow (% per snow event): > 0 is adding snow, < 0 is removing snow
+0.0			# runoff/runon of snowmelt water (% per snowmelt event): > 0 is runoff, < 0 is runon
+
+
+#--- Activate/deactivate weather generator
 2			# 0 = use historical data only
 			# 1 = use weather generator for (partially) missing weather inputs
 			# 2 = use weather generator for all weather (don't check weather inputs)
+
+7			# Seed random number generator for weather generator (only used if SOILWAT2)
+			# (seed with 0 to use current time)
+
+#--- Historical daily weather inputs
 -1		# first year to begin historical weather
 			# if -1, then use first year of simulation (see `years.in`)
 
-# Monthly scaling parameters:
+
+#--- Monthly scaling parameters:
 # Month 1 = January, Month 2 = February, etc.
 # PPT = multiplicative for daily PPT; max(0, scale * ppt)
 # MaxT = additive for daily max temperature [C]; scale + maxtemp


### PR DESCRIPTION
- pull in SOILWAT2 branch "feature_pcg_seeding"
* now, a random number sequence can be exactly reproduced ("initstate" and "initseq"), see https://github.com/DrylandEcology/SOILWAT2/pull/327
* see also https://github.com/DrylandEcology/SOILWAT2/issues/326
* function `RandSeed()` has now two arguments "initstate" and "initseq"
-> update STEPWAT2 calls to `RandSeed()` with new arguments

- new `set_all_rngs()` to set each STEPWAT2 random number generator to produce sequences of random numbers that are reproducible (if user-provided "seed" is non-zero) and
* unique among RNGs, iterations, years, and grid cells (most RNGs)
* unique among RNGs, iterations, and years but identical among grid cells (weather generator RNG).
* A user-provided "seed" of zero produces non-reproducible random number sequences which are non-coinciding among RNGs, iterations, and grid cells