### PR TITLE
Updates for new SOILWAT2 project structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 *.exe
 *.o
 *.so
+obj
 
 # Packages #
 ############

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "sw_src"]
 	path = sw_src
 	url = https://github.com/DrylandEcology/SOILWAT2.git
-	branch = feature_restructure
+	branch = release/devel_v7.0.0
         ignore = dirty

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "sw_src"]
 	path = sw_src
 	url = https://github.com/DrylandEcology/SOILWAT2.git
-	branch = release/devel_v7.0.0
+	branch = feature_restructure
         ignore = dirty

--- a/ST_colonization.c
+++ b/ST_colonization.c
@@ -9,8 +9,8 @@
  */
 
 #include "ST_colonization.h"
-#include "sw_src/myMemory.h"
-#include "sw_src/filefuncs.h"
+#include "sw_src/include/myMemory.h"
+#include "sw_src/include/filefuncs.h"
 #include "ST_functions.h"
 #include "ST_globals.h"
 

--- a/ST_defines.h
+++ b/ST_defines.h
@@ -17,7 +17,7 @@
 #ifndef STEPPE_DEF_H
 #define STEPPE_DEF_H
 
-#include "sw_src/generic.h"
+#include "sw_src/include/generic.h"
 
 /* see #include "ST_structs.h" below */
 

--- a/ST_environs.c
+++ b/ST_environs.c
@@ -14,11 +14,11 @@
 
 #include "ST_steppe.h"
 #include "ST_globals.h"
-#include "sw_src/pcg/pcg_basic.h"
-#include "sw_src/rands.h"
+#include "sw_src/external/pcg/pcg_basic.h"
+#include "sw_src/include/rands.h"
 #include "sxw.h" // externs `*SXW`
 #include "sxw_funcs.h"
-#include "sw_src/filefuncs.h"
+#include "sw_src/include/filefuncs.h"
 
 /*********** Locally Used Function Declarations ************/
 /***********************************************************/

--- a/ST_grid.c
+++ b/ST_grid.c
@@ -33,13 +33,13 @@
 #include <string.h>
 #include <ctype.h>
 #include <dirent.h>
-#include "sw_src/generic.h"
-#include "sw_src/filefuncs.h"
-#include "sw_src/myMemory.h"
-#include "sw_src/rands.h"
-#include "sw_src/SW_SoilWater.h" // externs SW_Soilwat
-#include "sw_src/SW_Weather.h" // externs SW_Weather
-#include "sw_src/SW_Markov.h"// externs `markov_rng`
+#include "sw_src/include/generic.h"
+#include "sw_src/include/filefuncs.h"
+#include "sw_src/include/myMemory.h"
+#include "sw_src/include/rands.h"
+#include "sw_src/include/SW_SoilWater.h" // externs SW_Soilwat
+#include "sw_src/include/SW_Weather.h" // externs SW_Weather
+#include "sw_src/include/SW_Markov.h"// externs `markov_rng`
 #include "ST_grid.h"
 #include "ST_steppe.h"
 #include "ST_globals.h" // externs `UseProgressBar`
@@ -51,12 +51,12 @@
 #include "ST_colonization.h"
 #include "ST_seedDispersal.h" // externs `UseSeedDispersal`
 #include "ST_mortality.h" // externs `mortality_rng`, `*_SomeKillage`, `UseCheatgrassWildfire`
-#include "sw_src/SW_Output.h"
-#include "sw_src/SW_Output_outtext.h"
-#include "sw_src/SW_Output_outarray.h"
+#include "sw_src/include/SW_Output.h"
+#include "sw_src/include/SW_Output_outtext.h"
+#include "sw_src/include/SW_Output_outarray.h"
 
-#include "sw_src/SW_Flow.h" // for `SW_FLW_init_run()`
-#include "sw_src/SW_Flow_lib.h" // for `SW_ST_init_run()`
+#include "sw_src/include/SW_Flow.h" // for `SW_FLW_init_run()`
+#include "sw_src/include/SW_Flow_lib.h" // for `SW_ST_init_run()`
 
 
 

--- a/ST_grid.h
+++ b/ST_grid.h
@@ -17,23 +17,23 @@
 /******** These modules are necessary to compile ST_grid.c ********/
 #include "ST_stats.h"
 #include "ST_defines.h"
-#include "sw_src/pcg/pcg_basic.h"
+#include "sw_src/external/pcg/pcg_basic.h"
 #include "sxw_vars.h"
-#include "sw_src/SW_Site.h"
-#include "sw_src/SW_SoilWater.h"
-#include "sw_src/SW_VegProd.h"
-#include "sw_src/SW_Model.h"
-#include "sw_src/SW_Weather.h"
+#include "sw_src/include/SW_Site.h"
+#include "sw_src/include/SW_SoilWater.h"
+#include "sw_src/include/SW_VegProd.h"
+#include "sw_src/include/SW_Model.h"
+#include "sw_src/include/SW_Weather.h"
 #include "ST_seedDispersal.h"
 
 /*********************** Grid Structures ****************************/
 
-/** 
+/**
  * \brief Soil layer information for a single [cell](\ref CellType)
- * 
+ *
  * This struct requires dynamic memory allocation, so be carefull when
  * instanciating it.
- * 
+ *
  * \ingroup GRID
  */
 typedef struct Soil_st

--- a/ST_indivs.c
+++ b/ST_indivs.c
@@ -21,8 +21,8 @@
 #include <stdlib.h>
 #include "ST_steppe.h"
 #include "ST_globals.h"
-#include "sw_src/filefuncs.h"
-#include "sw_src/myMemory.h"
+#include "sw_src/include/filefuncs.h"
+#include "sw_src/include/myMemory.h"
 
 
 /******** Modular External Function Declarations ***********/

--- a/ST_main.c
+++ b/ST_main.c
@@ -23,21 +23,21 @@
 #include <string.h>
 #include <stdlib.h>
 #include "ST_steppe.h"
-#include "sw_src/generic.h" // externs `*logfp`, `errstr`, `EchoInits`, `QuietMode`, `logged`
-#include "sw_src/filefuncs.h" // externs `inbuf`
-#include "sw_src/myMemory.h"
-#include "sw_src/SW_VegProd.h"
-#include "sw_src/SW_Control.h"
-#include "sw_src/pcg/pcg_basic.h"
-#include "sw_src/SW_Markov.h"// externs `markov_rng`
+#include "sw_src/include/generic.h" // externs `*logfp`, `errstr`, `EchoInits`, `QuietMode`, `logged`
+#include "sw_src/include/filefuncs.h" // externs `inbuf`
+#include "sw_src/include/myMemory.h"
+#include "sw_src/include/SW_VegProd.h"
+#include "sw_src/include/SW_Control.h"
+#include "sw_src/external/pcg/pcg_basic.h"
+#include "sw_src/include/SW_Markov.h"// externs `markov_rng`
 
 #include "sxw_funcs.h"
 #include "sxw.h"
 // externs `prepare_IterationSummary`, `storeAllIterations`
-#include "sw_src/SW_Output.h"
-#include "sw_src/SW_Output_outtext.h" // externs `print_IterationSummary`
-#include "sw_src/SW_Output_outarray.h"
-#include "sw_src/rands.h"
+#include "sw_src/include/SW_Output.h"
+#include "sw_src/include/SW_Output_outtext.h" // externs `print_IterationSummary`
+#include "sw_src/include/SW_Output_outarray.h"
+#include "sw_src/include/rands.h"
 #include "ST_functions.h" // externs `environs_rng`, `resgroups_rng`, `species_rng`
 #include "ST_spinup.h"
 #include "ST_stats.h"

--- a/ST_mortality.c
+++ b/ST_mortality.c
@@ -23,12 +23,12 @@
 #include <string.h>
 
 #include "ST_mortality.h"
-#include "sw_src/filefuncs.h"
-#include "sw_src/rands.h"
-#include "sw_src/myMemory.h"
+#include "sw_src/include/filefuncs.h"
+#include "sw_src/include/rands.h"
+#include "sw_src/include/myMemory.h"
 #include "ST_steppe.h"
 #include "ST_globals.h"
-#include "sw_src/pcg/pcg_basic.h"
+#include "sw_src/external/pcg/pcg_basic.h"
 #include "sxw_vars.h"
 
 

--- a/ST_mortality.h
+++ b/ST_mortality.h
@@ -10,22 +10,22 @@
 #ifndef MORTALITY_H
 #define MORTALITY_H
 
-#include "sw_src/generic.h"
-#include "sw_src/pcg/pcg_basic.h"
+#include "sw_src/include/generic.h"
+#include "sw_src/external/pcg/pcg_basic.h"
 
 /* --------------------------- Exported Structs ---------------------------- */
 
 /**
  * \brief Information used when simulating the cheatgrass-wildfire loop.
- * 
+ *
  * The biggest determinant in cheatgrass driven wildfire is precipitation,
- * specifically precipitation in Spring and Winter. This struct stores the 
+ * specifically precipitation in Spring and Winter. This struct stores the
  * values from previous Spring and Winter precipitation as well as the running
  * averages of both.
- * 
+ *
  * Note that "year" in this context refers to the water year, which runs from
  * October to September.
- * 
+ *
  * \sa _updateCheatgrassPrecip, where this struct is updated each year.
  * \author Chandler Haukap
  * \date 13 January 2020

--- a/ST_output.c
+++ b/ST_output.c
@@ -15,14 +15,14 @@
 #include <string.h>
 #include "ST_steppe.h"
 #include "ST_globals.h"
-#include "sw_src/filefuncs.h"
-#include "sw_src/myMemory.h"
+#include "sw_src/include/filefuncs.h"
+#include "sw_src/include/myMemory.h"
 
 
 /******** Modular External Function Declarations ***********/
 /* -- truly global functions are declared in functions.h --*/
 /***********************************************************/
-#include "sw_src/SW_Model.h" // externs `SW_Model`
+#include "sw_src/include/SW_Model.h" // externs `SW_Model`
 
 
 /*------------------------------------------------------*/

--- a/ST_params.c
+++ b/ST_params.c
@@ -23,9 +23,9 @@
 #include <ctype.h>
 #include <errno.h>
 #include "ST_steppe.h"
-#include "sw_src/filefuncs.h"
-#include "sw_src/myMemory.h"
-#include "sw_src/rands.h"
+#include "sw_src/include/filefuncs.h"
+#include "sw_src/include/myMemory.h"
+#include "sw_src/include/rands.h"
 #include "sxw_funcs.h"
 #include "ST_globals.h"
 #include "sxw_vars.h"

--- a/ST_resgroups.c
+++ b/ST_resgroups.c
@@ -29,9 +29,9 @@
 #include <string.h>
 #include "ST_steppe.h"
 #include "ST_globals.h"
-#include "sw_src/myMemory.h"
-#include "sw_src/rands.h"
-#include "sw_src/filefuncs.h"
+#include "sw_src/include/myMemory.h"
+#include "sw_src/include/rands.h"
+#include "sw_src/include/filefuncs.h"
 #include "sxw_funcs.h"
 
 

--- a/ST_seedDispersal.c
+++ b/ST_seedDispersal.c
@@ -14,9 +14,9 @@
 #include "ST_defines.h"
 #include "ST_grid.h"
 #include "ST_seedDispersal.h"
-#include "sw_src/rands.h"
-#include "sw_src/myMemory.h"
-#include "sw_src/rands.h"
+#include "sw_src/include/rands.h"
+#include "sw_src/include/myMemory.h"
+#include "sw_src/include/rands.h"
 
 float _distance(int x1, int y1, int x2, int y2, float cellWidth);
 Bool _shouldProduceSeeds(SppIndex sp);

--- a/ST_species.c
+++ b/ST_species.c
@@ -22,9 +22,9 @@
 #include <string.h>
 #include "ST_steppe.h"
 #include "ST_globals.h"
-#include "sw_src/filefuncs.h"
-#include "sw_src/myMemory.h"
-#include "sw_src/rands.h"
+#include "sw_src/include/filefuncs.h"
+#include "sw_src/include/myMemory.h"
+#include "sw_src/include/rands.h"
 #include "ST_spinup.h"
 #include "ST_seedDispersal.h" // externs `UseSeedDispersal`
 

--- a/ST_spinup.c
+++ b/ST_spinup.c
@@ -17,21 +17,21 @@
 #include "ST_stats.h"
 #include "ST_globals.h" // externs UseProgressBar
 #include "ST_mortality.h"
-#include "sw_src/rands.h"
-#include "sw_src/SW_SoilWater.h" // externs SW_Soilwat
-#include "sw_src/SW_Weather.h" // externs SW_Weather
-#include "sw_src/SW_Site.h" // externs SW_Site
-#include "sw_src/SW_VegProd.h" // externs SW_VegProd
-#include "sw_src/SW_Markov.h"// externs `markov_rng`
+#include "sw_src/include/rands.h"
+#include "sw_src/include/SW_SoilWater.h" // externs SW_Soilwat
+#include "sw_src/include/SW_Weather.h" // externs SW_Weather
+#include "sw_src/include/SW_Site.h" // externs SW_Site
+#include "sw_src/include/SW_VegProd.h" // externs SW_VegProd
+#include "sw_src/include/SW_Markov.h"// externs `markov_rng`
 #include "sxw_funcs.h"
-#include "sw_src/myMemory.h"
-#include "sw_src/filefuncs.h"
+#include "sw_src/include/myMemory.h"
+#include "sw_src/include/filefuncs.h"
 #include "ST_progressBar.h"
 #include "ST_grid.h" // externs grid_rng
 // externs `prepare_IterationSummary`, `storeAllIterations`
-#include "sw_src/SW_Output.h"
-#include "sw_src/SW_Output_outtext.h" // externs `print_IterationSummary`
-#include "sw_src/SW_Output_outarray.h"
+#include "sw_src/include/SW_Output.h"
+#include "sw_src/include/SW_Output_outtext.h" // externs `print_IterationSummary`
+#include "sw_src/include/SW_Output_outarray.h"
 #include "ST_functions.h" // externs `environs_rng`, `resgroups_rng`, `species_rng`
 
 

--- a/ST_stats.c
+++ b/ST_stats.c
@@ -40,8 +40,8 @@
 
 #include <string.h>
 #include "ST_steppe.h"
-#include "sw_src/filefuncs.h"
-#include "sw_src/myMemory.h"
+#include "sw_src/include/filefuncs.h"
+#include "sw_src/include/myMemory.h"
 #include "ST_stats.h" // Contains most of the function declarations.
 #include "ST_seedDispersal.h" // externs `UseSeedDispersal`
 #include "ST_globals.h"

--- a/ST_structs.h
+++ b/ST_structs.h
@@ -23,7 +23,7 @@
 #ifndef STEPPE_STRUCT_DEF
 #define STEPPE_STRUCT_DEF
 
-#include "sw_src/generic.h"
+#include "sw_src/include/generic.h"
 #include "ST_mortality.h"
 
 /**

--- a/makefile
+++ b/makefile
@@ -21,12 +21,16 @@ CFLAGS = \
 sw2 = SOILWAT2
 lib_sw2 = lib$(sw2).a
 path_sw2 = sw_src
+path_sw2lib = $(path_sw2)/bin
 
+# Note: `-I$(path_sw2)` is required for `#include "external/pcg/pcg_basic.h"`
+# in SOILWAT2 headers that are included by STEPWAT2 code
 INC_DIRS = \
 	-I. \
 	-Isqlite-amalgamation \
-	-I$(path_sw2)/googletest/googletest \
-	-I$(path_sw2)/googletest/googletest/include \
+	-I$(path_sw2) \
+	-I$(path_sw2)/external/googletest/googletest \
+	-I$(path_sw2)/external/googletest/googletest/include \
 	-Itest
 
 sources_core = \
@@ -53,48 +57,62 @@ sources_core = \
 	ST_colonization.c
 
 sources_test = \
-	$(path_sw2)/googletest/googletest/src/gtest-all.cc \
-	$(path_sw2)/googletest/googletest/src/gtest_main.cc \
+	$(path_sw2)/external/googletest/googletest/src/gtest-all.cc \
+	$(path_sw2)/external/googletest/googletest/src/gtest_main.cc \
 	test/test_ST_mortality.cc
 
 sw2_sources = \
-	SW_Output_outarray.c \
-	SW_Output_outtext.c
+	src/SW_Output_outarray.c \
+	src/SW_Output_outtext.c
 
 
 objects_core = $(sources_core:%.c=obj/%.o)
 objects_core_test = $(sources_core:%.c=obj/%_TEST.o)
 objects_test = $(sources_test:%.cc=obj/%.o)
 
+dir_obj = \
+	obj \
+	obj/sqlite-amalgamation
+dir_test = \
+	obj/test \
+	obj/$(path_sw2)/external/googletest/googletest/src
 
-sw_LDFLAGS = $(LDFLAGS) -L. -L$(path_sw2)
+sw_LDFLAGS = $(LDFLAGS) -L. -L$(path_sw2lib)
 sw_LDLIBS = -l$(sw2) $(LDLIBS) -lm
 
 
 
-all: $(path_sw2)/$(lib_sw2) stepwat stepwat_test
+all: $(path_sw2lib)/$(lib_sw2) stepwat stepwat_test
 
-$(path_sw2)/$(lib_sw2):
-	@(cd $(path_sw2) && $(MAKE) $(lib_sw2) \
-		CC="$(CC)" CPPFLAGS="$(CPPFLAGS)" CFLAGS="$(CFLAGS)" AR="$(AR)" \
+$(path_sw2lib)/$(lib_sw2):
+# Note: `-I..` is required for `#include "ST_defines.h"`
+# in SOILWAT2 headers that are included by SOILWAT2 code
+	@(cd $(path_sw2) && $(MAKE) lib \
+		CC="$(CC)" CPPFLAGS="$(CPPFLAGS) -I.." CFLAGS="$(CFLAGS)" AR="$(AR)" \
 		sw_sources="$(sw2_sources)")
 
-stepwat: $(path_sw2)/$(lib_sw2) $(objects_core)
+stepwat: $(path_sw2lib)/$(lib_sw2) $(objects_core) | $(dir_obj)
 	$(CC) $(objects_core) $(CFLAGS) $(CPPFLAGS) $(sw_LDLIBS) $(sw_LDFLAGS) -o stepwat
 	-@cp stepwat testing.sagebrush.master
 	-@cp stepwat testing.sagebrush.master/Stepwat_Inputs
 
-stepwat_test: $(path_sw2)/$(lib_sw2) $(objects_core_test) $(objects_test)
+stepwat_test: $(path_sw2lib)/$(lib_sw2) $(objects_core_test) $(objects_test) | $(dir_obj) $(dir_test)
 	$(CXX) $(objects_core_test) $(objects_test) $(CFLAGS) $(CPPFLAGS) $(sw_LDLIBS) $(sw_LDFLAGS) -o stepwat_test
 
-obj/%.o: %.c
+obj/%.o: %.c | $(dir_obj)
 	$(CC) $(CFLAGS) $(CPPFLAGS) $(INC_DIRS) -c $< -o $@
 
-obj/%.o: %.cc
+obj/%.o: %.cc | $(dir_obj)
 	$(CXX) $(CFLAGS) $(CPPFLAGS) $(INC_DIRS) -std=gnu++11 -c $< -o $@
 
-obj/%_TEST.o: %.c
+obj/%_TEST.o: %.c | $(dir_obj) $(dir_test)
 	$(CC) $(CFLAGS) $(CPPFLAGS) $(INC_DIRS) -DSTDEBUG -c $< -o $@
+
+
+#--- Create directories
+$(dir_obj) $(dir_test):
+		-@mkdir -p $@
+
 
 .PHONY: run_tests
 run_tests: stepwat_test
@@ -117,7 +135,7 @@ clean: cleanobjs cleanbin documentation_clean
 .PHONY: cleanobjs
 cleanobjs:
 	-@find . -type f -name '*.o' -delete
-	-@$(RM) -f $(path_sw2)/$(lib_sw2)
+	-@$(RM) -f $(path_sw2lib)/$(lib_sw2)
 
 .PHONY: cleanbin
 cleanbin:

--- a/obj/sqlite-amalgamation/.gitignore
+++ b/obj/sqlite-amalgamation/.gitignore
@@ -1,4 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore

--- a/obj/sw_src/googletest/googletest/src/.gitignore
+++ b/obj/sw_src/googletest/googletest/src/.gitignore
@@ -1,4 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore

--- a/obj/sw_src/pcg/.gitignore
+++ b/obj/sw_src/pcg/.gitignore
@@ -1,4 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore

--- a/obj/test/.gitignore
+++ b/obj/test/.gitignore
@@ -1,4 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore

--- a/sxw.c
+++ b/sxw.c
@@ -48,27 +48,27 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include "sw_src/generic.h" // externs `errstr`
-#include "sw_src/filefuncs.h" // externs `inbuf`
-#include "sw_src/myMemory.h"
+#include "sw_src/include/generic.h" // externs `errstr`
+#include "sw_src/include/filefuncs.h" // externs `inbuf`
+#include "sw_src/include/myMemory.h"
 #include "ST_steppe.h"
 #include "ST_globals.h"
-#include "sw_src/SW_Defines.h"
+#include "sw_src/include/SW_Defines.h"
 #include "sxw.h"
 #include "sxw_funcs.h"
 #include "sxw_module.h"
-#include "sw_src/SW_Control.h"
-#include "sw_src/SW_Model.h"
-#include "sw_src/SW_VegProd.h"
-#include "sw_src/SW_Carbon.h"
-#include "sw_src/SW_Site.h"
-#include "sw_src/SW_SoilWater.h"
-#include "sw_src/SW_Files.h"
-#include "sw_src/SW_Weather.h"
-#include "sw_src/SW_Markov.h"
-#include "sw_src/SW_Output.h" // externs `prepare_IterationSummary`, `storeAllIterations`
-#include "sw_src/rands.h"
-#include "sw_src/pcg/pcg_basic.h"
+#include "sw_src/include/SW_Control.h"
+#include "sw_src/include/SW_Model.h"
+#include "sw_src/include/SW_VegProd.h"
+#include "sw_src/include/SW_Carbon.h"
+#include "sw_src/include/SW_Site.h"
+#include "sw_src/include/SW_SoilWater.h"
+#include "sw_src/include/SW_Files.h"
+#include "sw_src/include/SW_Weather.h"
+#include "sw_src/include/SW_Markov.h"
+#include "sw_src/include/SW_Output.h" // externs `prepare_IterationSummary`, `storeAllIterations`
+#include "sw_src/include/rands.h"
+#include "sw_src/external/pcg/pcg_basic.h"
 
 
 /*************** Global Variable Declarations ***************/

--- a/sxw.c
+++ b/sxw.c
@@ -1109,7 +1109,7 @@ void _print_debuginfo(void) {
 
 
 #ifdef DEBUG_MEM
-#include "sw_src/myMemory.h"
+#include "sw_src/include/myMemory.h"
 /*======================================================*/
 void SXW_SetMemoryRefs( void) {
 /* when debugging memory problems, use the bookkeeping

--- a/sxw.h
+++ b/sxw.h
@@ -24,10 +24,10 @@
 // The number of transpiration values retained by transp_data
 #define MAX_WINDOW 100
 
-#include "sw_src/SW_Times.h"
+#include "sw_src/include/SW_Times.h"
 #include "ST_defines.h"
-#include "sw_src/SW_Defines.h"
-#include "sw_src/pcg/pcg_basic.h"
+#include "sw_src/include/SW_Defines.h"
+#include "sw_src/external/pcg/pcg_basic.h"
 
 
 

--- a/sxw_environs.c
+++ b/sxw_environs.c
@@ -15,13 +15,13 @@
 
 #include "ST_steppe.h"
 #include "ST_globals.h" // externs `*Env`
-#include "sw_src/SW_Defines.h"
+#include "sw_src/include/SW_Defines.h"
 #include "sxw.h" // externs `*SXW`
 #include "sxw_module.h"
-#include "sw_src/SW_Model.h" // externs SW_Model
-#include "sw_src/SW_Site.h" // externs SW_Site
-#include "sw_src/SW_SoilWater.h" // externs SW_Soilwat
-#include "sw_src/SW_Weather.h" // externs SW_Weather
+#include "sw_src/include/SW_Model.h" // externs SW_Model
+#include "sw_src/include/SW_Site.h" // externs SW_Site
+#include "sw_src/include/SW_SoilWater.h" // externs SW_Soilwat
+#include "sw_src/include/SW_Weather.h" // externs SW_Weather
 
 
 

--- a/sxw_main.c
+++ b/sxw_main.c
@@ -17,9 +17,9 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include "ST_steppe.h"
-#include "sw_src/generic.h" // externs `errstr`
-#include "sw_src/filefuncs.h" // externs `inbuf`
-#include "sw_src/myMemory.h"
+#include "sw_src/include/generic.h" // externs `errstr`
+#include "sw_src/include/filefuncs.h" // externs `inbuf`
+#include "sw_src/include/myMemory.h"
 #include "sxw_funcs.h"
 
 /* for the chdir function */

--- a/sxw_module.h
+++ b/sxw_module.h
@@ -14,11 +14,11 @@
 #ifndef SXW_MODULE_DEF
 #define SXW_MODULE_DEF
 
-#include "sw_src/SW_Control.h"
-#include "sw_src/SW_Model.h"
-#include "sw_src/SW_VegProd.h"
-#include "sw_src/SW_SoilWater.h"
-#include "sw_src/SW_Files.h"
+#include "sw_src/include/SW_Control.h"
+#include "sw_src/include/SW_Model.h"
+#include "sw_src/include/SW_VegProd.h"
+#include "sw_src/include/SW_SoilWater.h"
+#include "sw_src/include/SW_Files.h"
 
 /* some macros for the production conversion array */
 #define PC_Bmass 0

--- a/sxw_resource.c
+++ b/sxw_resource.c
@@ -13,23 +13,23 @@
 /* --------------------------------------------------- */
 
 
-#include "sw_src/generic.h"
-#include "sw_src/rands.h"
-#include "sw_src/filefuncs.h"
-#include "sw_src/myMemory.h"
+#include "sw_src/include/generic.h"
+#include "sw_src/include/rands.h"
+#include "sw_src/include/filefuncs.h"
+#include "sw_src/include/myMemory.h"
 #include "ST_steppe.h"
 #include "ST_globals.h"
-#include "sw_src/SW_Defines.h"
+#include "sw_src/include/SW_Defines.h"
 #include "sxw.h" // externs `*SXWResources`, `transp_window`, `resource_rng`
 #include "sxw_module.h"
 #include "sxw_vars.h"
-#include "sw_src/SW_Control.h"
-#include "sw_src/SW_Site.h"
-#include "sw_src/SW_SoilWater.h"
-#include "sw_src/SW_VegProd.h"
-#include "sw_src/SW_Files.h"
-#include "sw_src/SW_Times.h"
-#include "sw_src/pcg/pcg_basic.h"
+#include "sw_src/include/SW_Control.h"
+#include "sw_src/include/SW_Site.h"
+#include "sw_src/include/SW_SoilWater.h"
+#include "sw_src/include/SW_VegProd.h"
+#include "sw_src/include/SW_Files.h"
+#include "sw_src/include/SW_Times.h"
+#include "sw_src/external/pcg/pcg_basic.h"
 
 
 

--- a/sxw_soilwat.c
+++ b/sxw_soilwat.c
@@ -39,23 +39,23 @@
 /* --------------------------------------------------- */
 
 
-#include "sw_src/generic.h"
-#include "sw_src/filefuncs.h"
-#include "sw_src/myMemory.h"
-#include "sw_src/Times.h"
+#include "sw_src/include/generic.h"
+#include "sw_src/include/filefuncs.h"
+#include "sw_src/include/myMemory.h"
+#include "sw_src/include/Times.h"
 #include "ST_steppe.h"
 #include "ST_globals.h"
-#include "sw_src/SW_Defines.h"
+#include "sw_src/include/SW_Defines.h"
 #include "sxw.h" // externs `*SXWResources`
 #include "sxw_module.h"
 #include "sxw_vars.h"
-#include "sw_src/SW_Control.h"
-#include "sw_src/SW_Weather.h" // externs `SW_Weather`
-#include "sw_src/SW_Model.h" // externs `SW_Model`
-#include "sw_src/SW_Site.h" // externs `SW_Site`
-#include "sw_src/SW_SoilWater.h"
-#include "sw_src/SW_VegProd.h" // externs `SW_VegProd`
-#include "sw_src/SW_Files.h"
+#include "sw_src/include/SW_Control.h"
+#include "sw_src/include/SW_Weather.h" // externs `SW_Weather`
+#include "sw_src/include/SW_Model.h" // externs `SW_Model`
+#include "sw_src/include/SW_Site.h" // externs `SW_Site`
+#include "sw_src/include/SW_SoilWater.h"
+#include "sw_src/include/SW_VegProd.h" // externs `SW_VegProd`
+#include "sw_src/include/SW_Files.h"
 
 
 

--- a/sxw_sql.c
+++ b/sxw_sql.c
@@ -12,9 +12,9 @@
 #include <sqlite3.h>
 #include "ST_steppe.h"
 #include "ST_globals.h"
-#include "sw_src/SW_Model.h" // externs `SW_Model`
-#include "sw_src/SW_Site.h" // externs `SW_Site`
-#include "sw_src/SW_VegProd.h" // externs `SW_VegProd`
+#include "sw_src/include/SW_Model.h" // externs `SW_Model`
+#include "sw_src/include/SW_Site.h" // externs `SW_Site`
+#include "sw_src/include/SW_VegProd.h" // externs `SW_VegProd`
 #include "sxw_module.h"
 #include "sxw.h" // externs `*SXW`, `*SXWResources`
 

--- a/test/test_ST_mortality.h
+++ b/test/test_ST_mortality.h
@@ -1,8 +1,8 @@
 #ifndef TEST_ST_MORTALITY_H
 #define TEST_ST_MORTALITY_H
 
-#include "sw_src/generic.h"
-#include "sw_src/myMemory.h"
+#include "sw_src/include/generic.h"
+#include "sw_src/include/myMemory.h"
 #include "ST_defines.h"
 #include "ST_globals.h"
 


### PR DESCRIPTION
- switch to SOILWAT2 branch feature_restructure

- paths renamed in submodule SOILWAT2
* *.c -> src/
* *.h -> include
* pcg/ -> external/pcg/
* googletest/ -> external/googletest/

- makefile gained ability to create required paths at obj/ -> remove obj/ and fixed nested folder structure
-> remove nested `.gitignore` for each subfolder of obj/ -> add obj to global `.gitignore`