### PR TITLE
Updates for SOILWAT2 (v6.7.0): fix its "vegetation establishment"

### DIFF
--- a/testing.sagebrush.master/Stepwat_Inputs/Input/sxw/Input/estab.in
+++ b/testing.sagebrush.master/Stepwat_Inputs/Input/sxw/Input/estab.in
@@ -1,13 +1,21 @@
-# list of filenames for which to check establishment
-# each filename pertains to a species and contains the 
+#------ Input file for (optional) plant establishment
+
+
+#--- Activate/deactivate plant establishment calculations
+
+0	# 1/0 = do/don't calculate and output establishment conditions
+
+
+#--- File names with establishment parameters (only used if activated)
+# Each file pertains to a species and contains the
 # soil moisture and timing parameters required for the
 # species to establish in a given year.
 # There is no limit to the number of files in the list.
-# to suppress checking establishment, comment all the 
-# lines below.
+# File names with paths relative to the SOILWAT2 directory (`_ProjDir`)
 
-0   # use flag; 1=check establishment, 0=don't check, ignore following
-bouteloua.estab
-#aristida.estab
-#vulpia.estab
-#opuntia.estab
+Input/estab/bouteloua.estab
+Input/estab/bromus.estab
+
+#Input/estab/aristida.estab
+#Input/estab/vulpia.estab
+#Input/estab/opuntia.estab

--- a/testing.sagebrush.master/Stepwat_Inputs/Input/sxw/Input/estab/bouteloua.estab
+++ b/testing.sagebrush.master/Stepwat_Inputs/Input/sxw/Input/estab/bouteloua.estab
@@ -1,4 +1,5 @@
 bogr	# 4-char name of species
+3    # Vegetation type of species (0, trees; 1, shrubs; 2, forbs; 3 grasses)
 # soil layer parameters
 2	# number of layers affecting establishment
 10.0	# SWP (bars) requirement for germination (top layer)

--- a/testing.sagebrush.master/Stepwat_Inputs/Input/sxw/Input/estab/bromus.estab
+++ b/testing.sagebrush.master/Stepwat_Inputs/Input/sxw/Input/estab/bromus.estab
@@ -1,4 +1,5 @@
 brte	# 4-char name of species
+3    # Vegetation type of species (0, trees; 1, shrubs; 2, forbs; 3 grasses)
 # soil layer parameters
 3	# number of layers affecting establishment
 10.0	# SWP (bars) requirement for germination (top layer)


### PR DESCRIPTION
- SOILWAT2's "vegetation establishment" module works again (also as part of STEPWAT2); see https://github.com/DrylandEcology/SOILWAT2/issues/336
- note: these are calculations are made on simulated SOILWAT2's conditions and do not inform simulations (no feedback)

- input files with species establishment parameters "<species>.estab" now organized in a subfolder within SOILWAT2's inputs
- new input parameter "vegetation type" that associates a species with one of SOILWAT2's simulated vegetation types

- notes
* SOILWAT2's "establishment" is calculated under the following conditions: (i) there are input files with species establishment parameters; (ii) at least one of those files is correctly listed in `"estab.in"` and the input flag in `"estab.in"` is on
* these establishment results are included in the output files only if `"ESTABL"` is turned on in `"outsetup.in"`
* default values: calculations are turned off and output is turned off