### PR TITLE
Prepare STEPWAT2 to handle SOILWAT2's additional daily inputs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "sw_src"]
 	path = sw_src
 	url = https://github.com/DrylandEcology/SOILWAT2.git
-	branch = release/devel_v7.0.0
+	branch = read_more_daily_input
         ignore = dirty

--- a/sxw_soilwat.c
+++ b/sxw_soilwat.c
@@ -56,6 +56,7 @@
 #include "sw_src/include/SW_SoilWater.h"
 #include "sw_src/include/SW_VegProd.h" // externs `SW_VegProd`
 #include "sw_src/include/SW_Files.h"
+#include "sw_src/include/SW_Sky.h" // externs SW_Sky
 
 
 
@@ -102,6 +103,8 @@ void _sxw_sw_setup (RealF sizes[]) {
 */
 void _sxw_generate_weather(void) {
   SW_WEATHER *w = &SW_Weather;
+  SW_SKY *sky = &SW_Sky;
+  int flag;
 
   deallocateAllWeather(w);
   w->n_years = 1;
@@ -116,12 +119,26 @@ void _sxw_generate_weather(void) {
     );
   }
 
+  // Make sure monthly flags are set to interpolate monthly values into daily values
+  w->use_humidityMonthly = swTRUE;
+  w->use_cloudCoverMonthly = swTRUE;
+  w->use_windSpeedMonthly = swTRUE;
+
   readAllWeather(
     w->allHist,
     w->startYear,
     w->n_years,
     swTRUE, // `use_weathergenerator_only`
-    w->name_prefix // not used because `use_weathergenerator_only`
+    w->name_prefix, // not used because `use_weathergenerator_only`
+	w->use_cloudCoverMonthly,
+	w->use_humidityMonthly,
+	w->use_windSpeedMonthly,
+	w->n_input_forcings,
+	w->dailyInputIndices,
+	w->dailyInputFlags,
+	sky->cloudcov,
+	sky->windspeed,
+	sky->r_humidity
   );
 
   finalizeAllWeather(w); // run the weather generator

--- a/sxw_soilwat.c
+++ b/sxw_soilwat.c
@@ -104,7 +104,6 @@ void _sxw_sw_setup (RealF sizes[]) {
 void _sxw_generate_weather(void) {
   SW_WEATHER *w = &SW_Weather;
   SW_SKY *sky = &SW_Sky;
-  int flag;
 
   deallocateAllWeather(w);
   w->n_years = 1;

--- a/testing.sagebrush.master/Stepwat_Inputs/Input/sxw/Input/weathsetup.in
+++ b/testing.sagebrush.master/Stepwat_Inputs/Input/sxw/Input/weathsetup.in
@@ -15,6 +15,33 @@
 7			# Seed random number generator for weather generator (only used if SOILWAT2)
 			# (seed with 0 to use current time)
 
+#--- Flags describing mean monthly climate input usage:
+# 0 = Don't use mean monthly input
+# 1 = Use mean monthly input (climate.in) and override respective flag for daily input, if flags conflict
+1            # Sky cover
+1            # Wind speed
+1            # Relative humidity
+
+
+#--- Flags describing daily weather input files "weath.YYYY":
+# 0 = Variable is absent
+# 1 = Daily variable present
+# Note: The order of input values within input files must match the order of flags below (e.g., cloud cover cannot precede minimum temperature)
+# Note: If maximum/minimum temperature or precipitation is set to 0 or a flag is set to 1, and the input data is not complete, the program will crash
+1			# Maximum daily temperature [C]
+1			# Minimum daily temperature [C]
+1			# Precipitation [cm]
+0			# Cloud cover [%]
+0			# Wind speed [m/s]
+0			# Wind speed eastward component [m/s]
+0			# Wind speed northward component [m/s]
+0			# Relative humidity [%]
+0			# Maximum relative humidity [%]
+0			# Minimum relative humidity [%]
+0			# Specific humidity [%]
+0			# Dew point temperature [C]
+0			# Actual vapor pressure [kPa]
+0			# Downward surface shortwave radiation [W/m2], i.e., flux density for a (hypothetical) flat horizon averaged over the daylight period of the day
 
 #--- Monthly scaling parameters:
 # Month 1 = January, Month 2 = February, etc.
@@ -24,16 +51,18 @@
 # SkyCover = additive for mean monthly sky cover [%]; min(100, max(0, scale + sky cover))
 # Wind = multiplicative for mean monthly wind speed; max(0, scale * wind speed)
 # rH = additive for mean monthly relative humidity [%]; min(100, max(0, scale + rel. Humidity))
-#Mon   PPT    MaxT    MinT  SkyCover   Wind    rH
-1    1.000    0.00    0.00       0.0    1.0   0.0
-2    1.000    0.00    0.00       0.0    1.0   0.0
-3    1.000    0.00    0.00       0.0    1.0   0.0
-4    1.000    0.00    0.00       0.0    1.0   0.0
-5    1.000    0.00    0.00       0.0    1.0   0.0
-6    1.000    0.00    0.00       0.0    1.0   0.0
-7    1.000    0.00    0.00       0.0    1.0   0.0
-8    1.000    0.00    0.00       0.0    1.0   0.0
-9    1.000    0.00    0.00       0.0    1.0   0.0
-10   1.000    0.00    0.00       0.0    1.0   0.0
-11   1.000    0.00    0.00       0.0    1.0   0.0
-12   1.000    0.00    0.00       0.0    1.0   0.0
+# ActVP = multiplicative for actual vapor pressure [kPa]; max(0, scale * actual vapor pressure)
+# ShortWR = multiplicative for shortwave radiation [W/m2]; max(0, scale * shortwave radiation)
+#Mon   PPT    MaxT    MinT  SkyCover   Wind    rH    ActVP    ShortWR
+1    1.000    0.00    0.00       0.0    1.0   0.0      1.0        1.0
+2    1.000    0.00    0.00       0.0    1.0   0.0      1.0        1.0
+3    1.000    0.00    0.00       0.0    1.0   0.0      1.0        1.0
+4    1.000    0.00    0.00       0.0    1.0   0.0      1.0        1.0
+5    1.000    0.00    0.00       0.0    1.0   0.0      1.0        1.0
+6    1.000    0.00    0.00       0.0    1.0   0.0      1.0        1.0
+7    1.000    0.00    0.00       0.0    1.0   0.0      1.0        1.0
+8    1.000    0.00    0.00       0.0    1.0   0.0      1.0        1.0
+9    1.000    0.00    0.00       0.0    1.0   0.0      1.0        1.0
+10   1.000    0.00    0.00       0.0    1.0   0.0      1.0        1.0
+11   1.000    0.00    0.00       0.0    1.0   0.0      1.0        1.0
+12   1.000    0.00    0.00       0.0    1.0   0.0      1.0        1.0


### PR DESCRIPTION
See SOILWAT2's PR https://github.com/DrylandEcology/SOILWAT2/pull/338 and issue https://github.com/DrylandEcology/SOILWAT2/issues/341

SOILWAT2 is gaining the ability to handle additional daily inputs (for atmospheric demand) while being fully backwards compatible. However, the weather generator is currently not updated to handle additional daily variables. This PR sets STEPWAT2 up to interact with SOILWAT2 as before, i.e., without utilizing the new daily variables.