### PR TITLE
Updates for SOILWAT2 v7.2.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "sw_src"]
 	path = sw_src
 	url = https://github.com/DrylandEcology/SOILWAT2.git
-	branch = master
+	branch = release/devel_v7.2.0
         ignore = dirty

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "sw_src"]
 	path = sw_src
 	url = https://github.com/DrylandEcology/SOILWAT2.git
-	branch = release/devel_v7.2.0
+	branch = master
         ignore = dirty

--- a/ST_colonization.c
+++ b/ST_colonization.c
@@ -163,20 +163,20 @@ void initColonization(char* fileName) {
     }
     if(valuesRead != 4 && valuesRead != 5) {
       Mem_Free(tempEvents);
-      LogError(&LogInfo, LOGFATAL, "Error reading colonization file:\n\tIncorrect"
+      LogError(&LogInfo, LOGERROR, "Error reading colonization file:\n\tIncorrect"
                " number of input arguments.\n\tIs it possible you put a space"
                " somewhere? Remember this file cannot contain spaces.");
       return;
     }
     if(fromCell < 0 || toCell > ((grid_Rows * grid_Cols) - 1)) {
       Mem_Free(tempEvents);
-      LogError(&LogInfo, LOGFATAL, "Error reading colonization file:"
+      LogError(&LogInfo, LOGERROR, "Error reading colonization file:"
                "\n\tInvalid cell range ( %d - %d ) specified.", fromCell, toCell);
       return;
     }
     if(startYear < 1 || startYear > SuperGlobals.runModelYears) {
       Mem_Free(tempEvents);
-      LogError(&LogInfo, LOGFATAL, "Error reading colonization file:"
+      LogError(&LogInfo, LOGERROR, "Error reading colonization file:"
                "\n\tInvalid start year (%d) specified.", startYear);
       return;
     }
@@ -184,7 +184,7 @@ void initColonization(char* fileName) {
     load_cell(toCell / grid_Cols, toCell % grid_Cols);
     if(Species_Name2Index(name) == -1) {
       Mem_Free(tempEvents);
-      LogError(&LogInfo, LOGFATAL, "Error reading colonization file:"
+      LogError(&LogInfo, LOGERROR, "Error reading colonization file:"
                "\n\tUnrecognized species name (%s).", name);
       return;
     }

--- a/ST_environs.c
+++ b/ST_environs.c
@@ -16,7 +16,7 @@
 
 #include "ST_steppe.h"
 #include "ST_globals.h"
-#include "sw_src/external/pcg/pcg_basic.h"
+#include "sw_src/include/SW_Defines.h"
 #include "sw_src/include/rands.h"
 #include "sxw.h" // externs `*SXW`
 #include "sxw_funcs.h"
@@ -34,7 +34,7 @@ static void _make_disturbance( void);
 /**************************************************************/
 /**************************************************************/
 
-pcg32_random_t environs_rng;
+sw_random_t environs_rng;
 
 
 void Env_Generate( void) {

--- a/ST_functions.h
+++ b/ST_functions.h
@@ -23,9 +23,9 @@
 /* =================================================== */
 /*            Externed Global Variables                */
 /* --------------------------------------------------- */
-extern pcg32_random_t environs_rng; // defined in ST_environs.c
-extern pcg32_random_t resgroups_rng; // defined in  ST_resgroups.c
-extern pcg32_random_t species_rng; // defined in ST_species.c
+extern sw_random_t environs_rng; // defined in ST_environs.c
+extern sw_random_t resgroups_rng; // defined in  ST_resgroups.c
+extern sw_random_t species_rng; // defined in ST_species.c
 
 
 

--- a/ST_grid.c
+++ b/ST_grid.c
@@ -69,7 +69,7 @@ char sd_Sep;
 int grid_Cells = 0;
 Bool UseDisturbances = 0, UseSoils = 0, sd_DoOutput = 0; //these are treated like booleans
 
-pcg32_random_t grid_rng;         // Gridded mode's unique RNG.
+sw_random_t grid_rng;         // Gridded mode's unique RNG.
 
 /**
  * \brief The main struct of the gridded mode module.

--- a/ST_grid.c
+++ b/ST_grid.c
@@ -485,7 +485,7 @@ static void _init_grid_files(void)
 		grid_directories[i] = Str_Dup(Str_TrimLeftQ(buf), &LogInfo);
 	}
 	if (i != N_GRID_DIRECTORIES)
-		LogError(&LogInfo, LOGFATAL, "Invalid files.in");
+		LogError(&LogInfo, LOGERROR, "Invalid files.in");
 
 	for (i = 0; i < N_GRID_FILES; i++)
 	{
@@ -494,7 +494,7 @@ static void _init_grid_files(void)
 		grid_files[i] = Str_Dup(Str_TrimLeftQ(buf), &LogInfo);
 	}
 	if (i != N_GRID_FILES)
-		LogError(&LogInfo, LOGFATAL, "Invalid files.in");
+		LogError(&LogInfo, LOGERROR, "Invalid files.in");
 
 	// opens the log file...
 	if (!strcmp("stdout", grid_files[GRID_FILE_LOGFILE])){
@@ -568,7 +568,7 @@ static void _init_soilwat_outputs(char* fileName) {
   int cell;
   FILE* inFile = fopen(fileName, "r");
   if(!inFile) {
-    LogError(&LogInfo, LOGFATAL, "Could not open SOILWAT2 output cells file."
+    LogError(&LogInfo, LOGERROR, "Could not open SOILWAT2 output cells file."
              "\n\tFile named \"%s\"", fileName);
   }
 
@@ -1163,11 +1163,11 @@ static void _read_disturbances_in(void)
 		}
 
 		if (num != 11)
-			LogError(&LogInfo, LOGFATAL, "Invalid %s file line %d wrong",
+			LogError(&LogInfo, LOGERROR, "Invalid %s file line %d wrong",
 					grid_files[GRID_FILE_DISTURBANCES], i + 2);
 	}
 	if (i != grid_Cells)
-		LogError(&LogInfo, LOGFATAL, "Invalid %s file wrong number of cells",
+		LogError(&LogInfo, LOGERROR, "Invalid %s file wrong number of cells",
 				grid_files[GRID_FILE_DISTURBANCES]);
 
     unload_cell();
@@ -1223,7 +1223,7 @@ static void _read_soils_in(void){
 
 	FILE* f = OpenFile(grid_files[GRID_FILE_SOILS], "r", &LogInfo);
 	if(!GetALine(f, buf)){ // Throw out the header line.
-		LogError(&LogInfo, LOGFATAL, "%s file empty.", grid_files[GRID_FILE_SOILS]);
+		LogError(&LogInfo, LOGERROR, "%s file empty.", grid_files[GRID_FILE_SOILS]);
 	}
 
 	for(i = 0; i < grid_Cells; ++i){
@@ -1232,17 +1232,17 @@ static void _read_soils_in(void){
 		load_cell(row, col);
 
 		if(!GetALine(f, buf)){
-			LogError(&LogInfo, LOGFATAL, "Too few lines in %s", grid_files[GRID_FILE_SOILS]);
+			LogError(&LogInfo, LOGERROR, "Too few lines in %s", grid_files[GRID_FILE_SOILS]);
 		}
 		lineReadReturnValue = _read_soil_line(buf, &tempSoil, 0);
 		if (lineReadReturnValue == SOIL_READ_FAILURE){
-			LogError(&LogInfo, LOGFATAL, "Error reading %s file.", grid_files[GRID_FILE_SOILS]);
+			LogError(&LogInfo, LOGERROR, "Error reading %s file.", grid_files[GRID_FILE_SOILS]);
 		}
 		/* If _read_soil_line didnt return SUCCESS or FAILURE,
 		   it returned a cell number to copy. */
 		else if (lineReadReturnValue != SOIL_READ_SUCCESS){
 			if(lineReadReturnValue > i){
-				LogError(&LogInfo, LOGFATAL, "%s: Attempted to copy values that have not been read yet.\n"
+				LogError(&LogInfo, LOGERROR, "%s: Attempted to copy values that have not been read yet.\n"
 				                          "\tIf you want to copy a soil make sure you define the layers"
 										  "the FIRST time you use it.", grid_files[GRID_FILE_SOILS]);
 			}
@@ -1253,11 +1253,11 @@ static void _read_soils_in(void){
 		else {
 			for(j = 1; j < tempSoil.num_layers; ++j){
 				if(!GetALine(f, buf)){
-					LogError(&LogInfo, LOGFATAL, "Too few lines in %s", grid_files[GRID_FILE_SOILS]);
+					LogError(&LogInfo, LOGERROR, "Too few lines in %s", grid_files[GRID_FILE_SOILS]);
 				}
 				lineReadReturnValue = _read_soil_line(buf, &tempSoil, j);
 				if(lineReadReturnValue != SOIL_READ_SUCCESS){
-					LogError(&LogInfo, LOGFATAL, "Different behavior is specified between layers %d and %d of"
+					LogError(&LogInfo, LOGERROR, "Different behavior is specified between layers %d and %d of"
 					                          " cell %d in file %s. (Perhaps you specified a cell to copy in one"
 											  " but not the other?)", j, j+1, i, grid_files[GRID_FILE_SOILS]);
 				}
@@ -1310,7 +1310,7 @@ static int _read_soil_line(char* buf, SoilType* destination, int layer){
 
 	if(cellNum > grid_Cells){
 		LogError(
-			&LogInfo, LOGFATAL,
+			&LogInfo, LOGERROR,
 			"%s: cell number (id=%d) is larger than number of cells in grid (n=%d).",
 			grid_files[GRID_FILE_SOILS], cellNum, grid_Cells
 		);
@@ -1324,7 +1324,7 @@ static int _read_soil_line(char* buf, SoilType* destination, int layer){
 
 		if(cellToCopy > grid_Cells){
 			LogError(
-				&LogInfo, LOGFATAL,
+				&LogInfo, LOGERROR,
 				"%s: cell to copy (id=%d) not present in grid (n=%d).",
 				grid_files[GRID_FILE_SOILS], cellToCopy, grid_Cells
 			);
@@ -1340,7 +1340,7 @@ static int _read_soil_line(char* buf, SoilType* destination, int layer){
 	if(entriesRead == 16) {
 		if(layerRead > destination->num_layers){
 			LogError(
-				&LogInfo, LOGFATAL,
+				&LogInfo, LOGERROR,
 				"%s: cell %d has too many soil layers (%d for max=%d).",
 				grid_files[GRID_FILE_SOILS], cellNum, layerRead, destination->num_layers
 			);
@@ -1437,7 +1437,7 @@ static void _read_spinup_species(void)
 		copy_cell_col = copy_cell % grid_Cols;
 
 		if (num != 3)
-			LogError(&LogInfo, LOGFATAL, "Invalid %s file", grid_files[GRID_FILE_SPINUP_SPECIES]);
+			LogError(&LogInfo, LOGERROR, "Invalid %s file", grid_files[GRID_FILE_SPINUP_SPECIES]);
 
 		int stringIndex = _get_value_index(buf, ',', 3); //gets us the index of the string that is right after what we just parsed in
 
@@ -1452,7 +1452,7 @@ static void _read_spinup_species(void)
 			continue;
 		}
 		else if (do_copy == 1)
-			LogError(&LogInfo, LOGFATAL,
+			LogError(&LogInfo, LOGERROR,
 					"Invalid %s file line %d invalid copy_cell attempt",
 					grid_files[GRID_FILE_SPINUP_SPECIES], i + 2);
 
@@ -1462,7 +1462,7 @@ static void _read_spinup_species(void)
 		{
 			num = sscanf(&buf[stringIndex], "%d,", &seeds_Avail);
 			if (num != 1){
-				LogError(&LogInfo, LOGFATAL, "Invalid %s file line %d invalid species input",
+				LogError(&LogInfo, LOGERROR, "Invalid %s file line %d invalid species input",
 						 grid_files[GRID_FILE_SPINUP_SPECIES], i + 2);
 			}
 
@@ -1479,7 +1479,7 @@ static void _read_spinup_species(void)
 	}
 
 	if (i != grid_Cells)
-		LogError(&LogInfo, LOGFATAL, "Invalid %s file, not enough cells",
+		LogError(&LogInfo, LOGERROR, "Invalid %s file, not enough cells",
 				grid_files[GRID_FILE_SPINUP_SPECIES]);
 
 	if(!isAnyCellOnForSpinup){
@@ -1535,13 +1535,13 @@ static void _read_grid_setup(void)
     GetALine(f, buf);
     i = sscanf(buf, "%d %d", &grid_Rows, &grid_Cols);
     if (i != 2)
-        LogError(&LogInfo, LOGFATAL,
+        LogError(&LogInfo, LOGERROR,
                  "Invalid grid setup file (rows/cols line wrong)");
 
     grid_Cells = grid_Cols * grid_Rows;
 
     if (grid_Cells > MAX_CELLS)
-        LogError(&LogInfo, LOGFATAL,
+        LogError(&LogInfo, LOGERROR,
                  "Number of cells in grid exceeds MAX_CELLS defined in ST_defines.h");
 
     /* Allocate the 2d array of cells now that we know how many we need */
@@ -1550,48 +1550,48 @@ static void _read_grid_setup(void)
     GetALine(f, buf);
     i = sscanf(buf, "%u", &UseDisturbances);
     if (i != 1)
-        LogError(&LogInfo, LOGFATAL,
+        LogError(&LogInfo, LOGERROR,
                  "Invalid grid setup file (disturbances line wrong)");
 
     GetALine(f, buf);
     i = sscanf(buf, "%u", &UseSoils);
     if (i != 1)
-        LogError(&LogInfo, LOGFATAL, "Invalid grid setup file (soils line wrong)");
+        LogError(&LogInfo, LOGERROR, "Invalid grid setup file (soils line wrong)");
 
     GetALine(f, buf);
     i = sscanf(buf, "%d", &j);
     if (i != 1)
-        LogError(&LogInfo, LOGFATAL,
+        LogError(&LogInfo, LOGERROR,
                  "Invalid grid setup file (seed dispersal line wrong)");
     UseSeedDispersal = itob(j);
 
 	GetALine(f, buf);
 	i = sscanf(buf, "%d", &shouldSpinup);
 	if(i < 1){
-		LogError(&LogInfo, LOGFATAL, "Invalid grid setup file (Spinup line wrong)");
+		LogError(&LogInfo, LOGERROR, "Invalid grid setup file (Spinup line wrong)");
 	}
 
 	GetALine(f, buf);
 	i = sscanf(buf, "%hd", &SuperGlobals.runSpinupYears);
 	if(i < 1){
-		LogError(&LogInfo, LOGFATAL, "Invalid grid setup file (Spinup years line wrong)");
+		LogError(&LogInfo, LOGERROR, "Invalid grid setup file (Spinup years line wrong)");
 	}
 
 	GetALine(f, buf);
 	i = sscanf(buf, "%u", &writeIndividualFiles);
 	if(i < 1){
-		LogError(&LogInfo, LOGFATAL, "Invalid grid setup file (Individual output line wrong)");
+		LogError(&LogInfo, LOGERROR, "Invalid grid setup file (Individual output line wrong)");
 	}
 
 	GetALine(f, buf);
 	if (sscanf(buf, "%u", &recordDispersalEvents) != 1) {
-		LogError(&LogInfo, LOGFATAL,
+		LogError(&LogInfo, LOGERROR,
 				"Invalid %s file: seed dispersal events output line\n", grid_files[GRID_FILE_SETUP]);
     }
 
 	GetALine(f, buf);
 	if (sscanf(buf, "%d", &outputSDData) != 1) {
-		LogError(&LogInfo, LOGFATAL, "Invalid grid setup file (Seed Dispersal Data Output\n");
+		LogError(&LogInfo, LOGERROR, "Invalid grid setup file (Seed Dispersal Data Output\n");
 	}
 
     CloseFile(&f, &LogInfo);
@@ -2002,7 +2002,7 @@ static void _separateSOILWAT2DailyOutput(char* fileName, int* cellNumbers) {
   FILE* inFile = fopen(fileName, "r");
 
   if(!inFile) {
-    LogError(&LogInfo, LOGFATAL, "Issue while separating SOILWAT2 output.\n\tFile"
+    LogError(&LogInfo, LOGERROR, "Issue while separating SOILWAT2 output.\n\tFile"
              "\"%s\" not found.", fileName);
   }
 
@@ -2066,7 +2066,7 @@ static void _separateSOILWAT2MonthlyOutput(char* fileName, int* cellNumbers) {
   FILE* inFile = fopen(fileName, "r");
 
   if(!inFile) {
-    LogError(&LogInfo, LOGFATAL, "Issue while separating SOILWAT2 output.\n\tFile"
+    LogError(&LogInfo, LOGERROR, "Issue while separating SOILWAT2 output.\n\tFile"
              "\"%s\" not found.", fileName);
   }
 
@@ -2128,7 +2128,7 @@ static void _separateSOILWAT2YearlyOutput(char* fileName, int* cellNumbers) {
   FILE* inFile = fopen(fileName, "r");
 
   if(!inFile) {
-    LogError(&LogInfo, LOGFATAL, "Issue while separating SOILWAT2 output.\n\tFile"
+    LogError(&LogInfo, LOGERROR, "Issue while separating SOILWAT2 output.\n\tFile"
              "\"%s\" not found.", fileName);
   }
 

--- a/ST_grid.h
+++ b/ST_grid.h
@@ -17,7 +17,7 @@
 /******** These modules are necessary to compile ST_grid.c ********/
 #include "ST_stats.h"
 #include "ST_defines.h"
-#include "sw_src/external/pcg/pcg_basic.h"
+#include "sw_src/include/SW_Defines.h"
 #include "sxw_vars.h"
 #include "sw_src/include/SW_Site.h"
 #include "sw_src/include/SW_SoilWater.h"
@@ -306,7 +306,7 @@ typedef enum
 /* =================================================== */
 /*            Externed Global Variables                */
 /* --------------------------------------------------- */
-extern pcg32_random_t grid_rng;
+extern sw_random_t grid_rng;
 extern CellType** gridCells;
 extern int grid_Rows;
 extern int grid_Cols;

--- a/ST_indivs.c
+++ b/ST_indivs.c
@@ -460,7 +460,7 @@ void _delete (IndivType *ndv)
 
   if ((s->est_count > 0 && s->IndvHead == NULL)
      || (s->est_count == 0 && s->IndvHead != NULL))
-     LogError(&LogInfo, LOGFATAL,
+     LogError(&LogInfo, LOGERROR,
               "PGMR: Indiv Count out of sync in _delete()");
 
   Mem_Free(ndv);
@@ -489,7 +489,7 @@ void Indiv_SortSize( const byte sorttype,
     case SORT_A: cmpfunc = Indiv_CompSize_A; break;
     case SORT_D: cmpfunc = Indiv_CompSize_D; break;
     default:
-      LogError(&LogInfo, LOGFATAL,
+      LogError(&LogInfo, LOGERROR,
              "Invalid sort mode in Indiv_SortSize");
   }
 

--- a/ST_main.c
+++ b/ST_main.c
@@ -28,7 +28,7 @@
 #include "sw_src/include/myMemory.h"
 #include "sw_src/include/SW_VegProd.h"
 #include "sw_src/include/SW_Control.h"
-#include "sw_src/external/pcg/pcg_basic.h"
+#include "sw_src/include/SW_Defines.h"
 
 #include "sxw_funcs.h"
 #include "sxw.h"

--- a/ST_main.c
+++ b/ST_main.c
@@ -26,6 +26,7 @@
 #include "sw_src/include/generic.h"
 #include "sw_src/include/filefuncs.h"
 #include "sw_src/include/myMemory.h"
+#include "sw_src/include/SW_Main_lib.h"
 #include "sw_src/include/SW_VegProd.h"
 #include "sw_src/include/SW_Control.h"
 #include "sw_src/include/SW_Defines.h"
@@ -110,8 +111,6 @@ void check_sizes(const char *);
 /***********************************************************/
 
 
-/** \brief optional place to put progress info */
-FILE *progfp;
 /** \brief Global struct holding species-specific variables. */
 SpeciesType  **Species;
 /** \brief Global struct holding rgroup-specific variables. */
@@ -135,7 +134,7 @@ LOG_INFO       LogInfo;
 /** \brief Global struct holding path information of SOILWAT2 (used by SOILWAT2) */
 PATH_INFO      PathInfo;
 /** \brief Local booleans to echo inputs/any output (used by SOILWAT2) */
-Bool           EchoInits, QuietMode;
+Bool           EchoInits;
 
 BmassFlagsType BmassFlags;
 /** \brief Global struct holding mortality output flags. */
@@ -167,7 +166,7 @@ int main(int argc, char **argv) {
   IntS year, iter;
 	Bool killedany;
 
-	LogInfo.logged = FALSE;
+	sw_init_logs(stdout, &LogInfo);
 	atexit(check_log);
 	/* provides a way to inform user that something
 	 * was logged.  see generic.h */
@@ -385,12 +384,12 @@ void Plot_Initialize(void) {
 
 		/* This should no longer occur following the resolution of issue #209 on GitHub */
 		if (!ZRO(getSpeciesRelsize(sp))) {
-			LogError(&LogInfo, LOGNOTE, 
+			LogError(&LogInfo, LOGWARN, 
 							 "%s relsize = %f in Plot_Initialize. This indicates that some individuals in this species were not killed.",
 							 Species[sp]->name, getSpeciesRelsize(sp));
 		}
 		if (Species[sp]->est_count) {
-			LogError(&LogInfo, LOGNOTE, "%s est_count (%d) forced "
+			LogError(&LogInfo, LOGWARN, "%s est_count (%d) forced "
 					"in Plot_Initialize", Species[sp]->name,
 					Species[sp]->est_count);
 			Species[sp]->est_count = 0;
@@ -409,7 +408,7 @@ void Plot_Initialize(void) {
 
     /* This should no longer occur following the resolution of issue #209 on GitHub */
 		if (!ZRO(getRGroupRelsize(rg))) {
-			LogError(&LogInfo, LOGNOTE, 
+			LogError(&LogInfo, LOGWARN, 
 							 "%s relsize = %f in Plot_Initialize. This indicates that some individuals in this RGroup were not killed.",
 							 RGroup[rg]->name, getRGroupRelsize(rg));
 			/*printf("in plot_initialize before forcing, Rgroup = %s, relsize = %f, est_count= %d\n",
@@ -418,7 +417,7 @@ void Plot_Initialize(void) {
                 
 		/* THIS NEVER SEEMS TO OCCUR */
 		if (RGroup[rg]->est_count) {
-			LogError(&LogInfo, LOGNOTE, "%s est_count (%d) forced "
+			LogError(&LogInfo, LOGWARN, "%s est_count (%d) forced "
 					"in Plot_Initialize", RGroup[rg]->name,
 					RGroup[rg]->est_count);
 			RGroup[rg]->est_count = 0;
@@ -583,7 +582,7 @@ static void init_args(int argc, char **argv) {
 
   /* Defaults */
   parm_SetFirstName( DFLT_FIRSTFILE);
-  QuietMode = EchoInits = UseSeedDispersal = FALSE;
+  LogInfo.QuietMode = EchoInits = UseSeedDispersal = FALSE;
   LogInfo.logfp = stderr;
 
 
@@ -654,7 +653,7 @@ static void init_args(int argc, char **argv) {
 		case 0: /* -d */
 			if (!ChDir(str))
 			{
-				LogError(&LogInfo, LOGFATAL, "Invalid project directory (%s)",
+				LogError(&LogInfo, LOGERROR, "Invalid project directory (%s)",
 						str);
 			}
 			break;
@@ -663,7 +662,7 @@ static void init_args(int argc, char **argv) {
 			break; /* -f */
 
 		case 2:
-			QuietMode = TRUE;
+			LogInfo.QuietMode = TRUE;
 			break; /* -q */
 
 		case 3:
@@ -671,7 +670,7 @@ static void init_args(int argc, char **argv) {
 			break; /* -e */
 
 		case 4:
-			progfp = stdout; /* -p */
+			LogInfo.logfp = stdout; /* -p */
 			UseProgressBar = TRUE;
 			break;
 
@@ -707,7 +706,7 @@ static void init_args(int argc, char **argv) {
 			}
 
 		default:
-			LogError(&LogInfo, LOGFATAL,
+			LogError(&LogInfo, LOGERROR,
 					"Programmer: bad option in main:init_args:switch");
 		}
 
@@ -729,8 +728,8 @@ static void check_log(void) {
 /* =================================================== */
 
   if (LogInfo.logfp != stdout) {
-    if (LogInfo.logged && !QuietMode)
-      fprintf(progfp, "\nCheck logfile for error messages.\n");
+    if ((LogInfo.stopRun || LogInfo.numWarnings > 0) && !LogInfo.QuietMode)
+      fprintf(LogInfo.logfp, "\nCheck logfile for error messages.\n");
 
     CloseFile(&LogInfo.logfp, &LogInfo);
   }

--- a/ST_mortality.c
+++ b/ST_mortality.c
@@ -1106,7 +1106,7 @@ static void _stretched_clonal( GrpIndex rg, Int start, Int last,
 
       /* Making sure PR will always be > 1 here */
       if (total_reduction > 1.0)
-        LogError(&LogInfo, LOGFATAL,
+        LogError(&LogInfo, LOGERROR,
             "PR too large in Mort_StretchClonal()\n");
 
       /* sum up relsizes for total size*/

--- a/ST_mortality.c
+++ b/ST_mortality.c
@@ -28,7 +28,7 @@
 #include "sw_src/include/myMemory.h"
 #include "ST_steppe.h"
 #include "ST_globals.h"
-#include "sw_src/external/pcg/pcg_basic.h"
+#include "sw_src/include/SW_Defines.h"
 #include "sxw_vars.h"
 
 
@@ -47,7 +47,7 @@
  *
  * \ingroup MORTALITY
  */
-pcg32_random_t mortality_rng;
+sw_random_t mortality_rng;
 
 /* ---------------------------- Exported Flags ----------------------------- */
 

--- a/ST_mortality.h
+++ b/ST_mortality.h
@@ -11,7 +11,7 @@
 #define MORTALITY_H
 
 #include "sw_src/include/generic.h"
-#include "sw_src/external/pcg/pcg_basic.h"
+#include "sw_src/include/SW_Defines.h"
 
 /* --------------------------- Exported Structs ---------------------------- */
 
@@ -117,7 +117,7 @@ typedef enum {
 /* =================================================== */
 /*            Externed Global Variables                */
 /* --------------------------------------------------- */
-extern pcg32_random_t mortality_rng;
+extern sw_random_t mortality_rng;
 extern Bool *_SomeKillage;
 extern Bool UseCheatgrassWildfire;
 

--- a/ST_params.c
+++ b/ST_params.c
@@ -149,7 +149,7 @@ void files_init( void ) {
   }
 
   if ( i < last) {
-    LogError(&LogInfo, LOGFATAL, "%s: Too few input files specified",
+    LogError(&LogInfo, LOGERROR, "%s: Too few input files specified",
                               MyFileName);
   }
 
@@ -176,7 +176,7 @@ static void _model_init( void) {
    /* ----------------------------------------------------*/
    /* scan for the first line*/
    if (!GetALine(f, inbuf)) {
-     LogError(&LogInfo, LOGFATAL, "%s: No data found!\n", MyFileName);
+     LogError(&LogInfo, LOGERROR, "%s: No data found!\n", MyFileName);
    } else {
      sscanf( inbuf, "%s %d %d",
              tmp,
@@ -188,7 +188,7 @@ static void _model_init( void) {
      SuperGlobals.runModelIterations = atoi(tmp);
      if (SuperGlobals.runModelIterations < 1 ||
          SuperGlobals.runModelYears < 1 ) {
-       LogError(&LogInfo, LOGFATAL,"Invalid parameters for RunModelIterations "
+       LogError(&LogInfo, LOGERROR,"Invalid parameters for RunModelIterations "
                "or RunModelYears (%s)",
                MyFileName);
      }
@@ -267,7 +267,7 @@ static void _env_init( void) {
             break;
       }
       if (x<nitems) {
-         LogError(&LogInfo, LOGFATAL, "%s: Invalid record %d",
+         LogError(&LogInfo, LOGERROR, "%s: Invalid record %d",
                  MyFileName, index);
       }
 
@@ -295,12 +295,12 @@ static void _plot_init( void) {
    /* ----------------------------------------------------*/
    /* scan for the first line*/
    if (!GetALine(f, inbuf)) {
-     LogError(&LogInfo, LOGFATAL, "%s: No data found!\n", MyFileName);
+     LogError(&LogInfo, LOGERROR, "%s: No data found!\n", MyFileName);
    }
 
    x = sscanf( inbuf, " %f", &Globals->plotsize);
    if (x < nitems) {
-     LogError(&LogInfo, LOGFATAL, "%s: Incorrect number of fields",
+     LogError(&LogInfo, LOGERROR, "%s: Incorrect number of fields",
                      MyFileName);
    }
 
@@ -344,11 +344,11 @@ static void _check_species( void) {
     if (cnt < g->max_spp_estab) {
       tripped = TRUE;
       g->max_spp_estab = cnt;
-      LogError(&LogInfo, LOGNOTE, "Max_Spp_Estab > Number of Spp for %s",
+      LogError(&LogInfo, LOGWARN, "Max_Spp_Estab > Number of Spp for %s",
               g->name);
     }
   }
-  if (tripped) LogError(&LogInfo, LOGNOTE,"Continuing.");
+  if (tripped) LogError(&LogInfo, LOGWARN,"Continuing.");
 
   /* -------------------------------------------*/
   /* determine max age for the species and
@@ -373,7 +373,7 @@ static void _check_species( void) {
     }
 
     if (minage == 1 && maxage != 1) {
-      LogError(&LogInfo, LOGFATAL, "%s: Can't mix annuals and perennials within a group\n"
+      LogError(&LogInfo, LOGERROR, "%s: Can't mix annuals and perennials within a group\n"
                       "Refer to the groups.in and species.in files\n",
                        RGroup[rg]->name);
     }
@@ -464,7 +464,7 @@ static void _bmassflags_init( void) {
    fin = OpenFile(MyFileName, "r", &LogInfo);
 
    if (!GetALine(fin, inbuf)) {
-     LogError(&LogInfo, LOGFATAL, "%s: No data found!\n", MyFileName);
+     LogError(&LogInfo, LOGERROR, "%s: No data found!\n", MyFileName);
    }
 
    x = sscanf( inbuf, "%s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s",
@@ -478,7 +478,7 @@ static void _bmassflags_init( void) {
    }
 
    if (x < nitems) {
-     LogError(&LogInfo, LOGFATAL, "%s: Invalid number of parameters",
+     LogError(&LogInfo, LOGERROR, "%s: Invalid number of parameters",
              MyFileName);
    }
 
@@ -552,8 +552,8 @@ static void _bmassflags_init( void) {
       LogError(&LogInfo, LOGWARN, "Can't remove old average biomass output file %s\n%s",
                 inbuf, strerror(errno) );
 
-  } else if (!MkDir(bMassAvgFile) ) {
-    LogError(&LogInfo, LOGFATAL,
+  } else if (!MkDir(bMassAvgFile, &LogInfo) ) {
+    LogError(&LogInfo, LOGERROR,
               "Can't make output path for average biomass file: %s\n%s",
               bMassAvgFile, strerror(errno));
   }
@@ -566,8 +566,8 @@ static void _bmassflags_init( void) {
       LogError(&LogInfo, LOGWARN, "Can't remove old biomass output files %s\n%s",
                 inbuf, strerror(errno) );
 
-  } else if (!MkDir(bMassPreFile)) {
-      LogError(&LogInfo, LOGFATAL,
+  } else if (!MkDir(bMassPreFile, &LogInfo)) {
+      LogError(&LogInfo, LOGERROR,
                 "Can't make output path for yearly biomass files: %s\n%s",
                 bMassPreFile, strerror(errno) );
   }
@@ -601,7 +601,7 @@ static void _mortflags_init( void) {
    fin = OpenFile(MyFileName, "r", &LogInfo);
 
    if (!GetALine(fin, inbuf)) {
-     LogError(&LogInfo, LOGFATAL, "%s No data found!\n", MyFileName);
+     LogError(&LogInfo, LOGERROR, "%s No data found!\n", MyFileName);
 
    }
 
@@ -617,7 +617,7 @@ static void _mortflags_init( void) {
    }
 
    if (x < nitems -2) {
-     LogError(&LogInfo, LOGFATAL,"%s: Invalid number of parameters",
+     LogError(&LogInfo, LOGERROR,"%s: Invalid number of parameters",
              MyFileName);
    }
 
@@ -661,8 +661,8 @@ static void _mortflags_init( void) {
         LogError(&LogInfo, LOGWARN, "Can't remove old average biomass output file %s\n%s",
                   inbuf, strerror(errno) );
 
-    } else if (!MkDir(mortAvgFile)) {
-      LogError(&LogInfo, LOGFATAL,
+    } else if (!MkDir(mortAvgFile, &LogInfo)) {
+      LogError(&LogInfo, LOGERROR,
                 "Can't make output path for average biomass file: %s\n%s",
                 mortAvgFile, strerror(errno));
     }
@@ -675,8 +675,8 @@ static void _mortflags_init( void) {
         LogError(&LogInfo, LOGWARN, "Can't remove old biomass output files %s\n%s",
                   inbuf, strerror(errno) );
 
-    } else if (!MkDir(mortPreFile) ) {
-        LogError(&LogInfo, LOGFATAL,
+    } else if (!MkDir(mortPreFile, &LogInfo) ) {
+        LogError(&LogInfo, LOGERROR,
                   "Can't make output path for yearly biomass files: %s\n%s",
                   mortPreFile, strerror(errno) );
     }
@@ -705,45 +705,45 @@ void maxrgroupspecies_init( void) {
     /* Resource group limits */
 
     if (!GetALine(f, inbuf)) {
-       LogError(&LogInfo, LOGFATAL, "%s: Could not read maximum resource groups allowed.", MyFileName);
+       LogError(&LogInfo, LOGERROR, "%s: Could not read maximum resource groups allowed.", MyFileName);
     }
 
     if (sscanf(inbuf, "%zu", &SuperGlobals.max_rgroups) != 1) {
-       LogError(&LogInfo, LOGFATAL, "%s: Could not read maximum resource groups allowed.", MyFileName);
+       LogError(&LogInfo, LOGERROR, "%s: Could not read maximum resource groups allowed.", MyFileName);
     }
 
     if (!GetALine(f, inbuf)) {
-       LogError(&LogInfo, LOGFATAL, "%s: Could not read maximum resource group name length.", MyFileName);
+       LogError(&LogInfo, LOGERROR, "%s: Could not read maximum resource group name length.", MyFileName);
     }
 
     if (sscanf(inbuf, "%zu", &SuperGlobals.max_groupnamelen) != 1) {
-       LogError(&LogInfo, LOGFATAL, "%s: Could not read maximum resource group name length.", MyFileName);
+       LogError(&LogInfo, LOGERROR, "%s: Could not read maximum resource group name length.", MyFileName);
     }
 
     /* Species limits */
 
     if (!GetALine(f, inbuf)) {
-       LogError(&LogInfo, LOGFATAL, "%s: Could not read maximum species allowed per resource group.", MyFileName);
+       LogError(&LogInfo, LOGERROR, "%s: Could not read maximum species allowed per resource group.", MyFileName);
     }
 
     if (sscanf(inbuf, "%zu", &SuperGlobals.max_spp_per_grp) != 1) {
-       LogError(&LogInfo, LOGFATAL, "%s: Could not read maximum species allowed per resource group.", MyFileName);
+       LogError(&LogInfo, LOGERROR, "%s: Could not read maximum species allowed per resource group.", MyFileName);
     }
 
     if (!GetALine(f, inbuf)) {
-       LogError(&LogInfo, LOGFATAL, "%s: Could not read maximum individuals allowed per species.", MyFileName);
+       LogError(&LogInfo, LOGERROR, "%s: Could not read maximum individuals allowed per species.", MyFileName);
     }
 
     if (sscanf(inbuf, "%zu", &SuperGlobals.max_indivs_per_spp) != 1) {
-       LogError(&LogInfo, LOGFATAL, "%s: Could not read maximum individuals allowed per species.", MyFileName);
+       LogError(&LogInfo, LOGERROR, "%s: Could not read maximum individuals allowed per species.", MyFileName);
     }
 
     if (!GetALine(f, inbuf)) {
-       LogError(&LogInfo, LOGFATAL, "%s: Could not read maximum species name length.", MyFileName);
+       LogError(&LogInfo, LOGERROR, "%s: Could not read maximum species name length.", MyFileName);
     }
 
     if (sscanf(inbuf, "%zu", &SuperGlobals.max_speciesnamelen) != 1) {
-       LogError(&LogInfo, LOGFATAL, "%s: Could not read maximum species name length.", MyFileName);
+       LogError(&LogInfo, LOGERROR, "%s: Could not read maximum species name length.", MyFileName);
     }
     
     CloseFile(&f, &LogInfo);
@@ -804,7 +804,7 @@ static void _rgroup_init( void) {
                &prop_killed, &prop_recovered,&grazing_frq, &prop_grazing,
                &grazingfreq_startyr, &biomass, &transpiration, &live_biomass);
      if (x < 25) {
-       LogError(&LogInfo, LOGFATAL, "%s: Too few columns in groups",
+       LogError(&LogInfo, LOGERROR, "%s: Too few columns in groups",
                MyFileName);
      }
 
@@ -821,7 +821,7 @@ static void _rgroup_init( void) {
    }/* end while*/
 
    if (!groupsok) {
-      LogError(&LogInfo, LOGFATAL, "%s: Incomplete input in group definitions",
+      LogError(&LogInfo, LOGERROR, "%s: Incomplete input in group definitions",
               MyFileName);
    }
 
@@ -837,14 +837,14 @@ static void _rgroup_init( void) {
                name,
                &nslope, &nint, &wslope, &wint, &dslope, &dint);
      if (x != 7) {
-       LogError(&LogInfo, LOGFATAL, "%s: Wrong number of columns in groups' wet/dry parms",
+       LogError(&LogInfo, LOGERROR, "%s: Wrong number of columns in groups' wet/dry parms",
                MyFileName);
      }
      _rgroup_add2( name, nslope, nint, wslope, wint, dslope, dint);
    }/* end while*/
 
    if (!groupsok) {
-      LogError(&LogInfo, LOGFATAL, "%s: Incomplete input in group definitions",
+      LogError(&LogInfo, LOGERROR, "%s: Incomplete input in group definitions",
               MyFileName);
    }
 
@@ -854,7 +854,7 @@ static void _rgroup_init( void) {
    x=sscanf( inbuf, "%s %f %f %f %f",
              name, &wslope, &wint, &dslope, &dint);
    if (x < 5) {
-     LogError(&LogInfo, LOGFATAL,
+     LogError(&LogInfo, LOGERROR,
           "%s: Too few values in succulent growth parameters",
            MyFileName);
    }
@@ -874,7 +874,7 @@ static void _rgroup_init( void) {
 
      x=sscanf( inbuf, "%u", &UseCheatgrassWildfire);
      if (x != 1) {
-       LogError(&LogInfo, LOGFATAL, "%s: Cheatgrass-Wildfire flag not read.",
+       LogError(&LogInfo, LOGERROR, "%s: Cheatgrass-Wildfire flag not read.",
                MyFileName);
      } 
    }/* end while*/
@@ -926,7 +926,7 @@ static void _rgroup_add2( char name[], RealF nslope, RealF nint, RealF wslope,
 
   rg = RGroup_Name2Index(name);
   if (rg < 0) {
-    LogError(&LogInfo, LOGFATAL, "%s: Mismatched name (%s) for succulents",
+    LogError(&LogInfo, LOGERROR, "%s: Mismatched name (%s) for succulents",
              MyFileName, name);
   }
 
@@ -948,7 +948,7 @@ static void _rgroup_add_disturbance( char name[], Int killyr, Int killfreq_start
 
    rg = RGroup_Name2Index(name);
    if (rg < 0) {
-     LogError(&LogInfo, LOGFATAL, "%s: Mismatched name (%s) for disturbance",
+     LogError(&LogInfo, LOGERROR, "%s: Mismatched name (%s) for disturbance",
              MyFileName, name);
    }
 
@@ -975,7 +975,7 @@ static void _rgroup_addsucculent( char name[], RealF wslope, RealF wint,
 
    rg = RGroup_Name2Index(name);
    if (rg < 0) {
-     LogError(&LogInfo, LOGFATAL, "%s: Mismatched name (%s) for succulents",
+     LogError(&LogInfo, LOGERROR, "%s: Mismatched name (%s) for succulents",
              MyFileName, name);
    }
    RGroup[rg]->succulent = TRUE;
@@ -1047,7 +1047,7 @@ static void _species_init( void) {
 				name, &rg, &turnon, &age, &slow, &dist, &eind, &vegi, &temp, clonal, &irate, &ratep,  &estab,
 				&minb, &maxb, &cohort);
       if (x != 16) {
-        LogError(&LogInfo, LOGFATAL, "%s: Wrong number of columns in species",
+        LogError(&LogInfo, LOGERROR, "%s: Wrong number of columns in species",
                 MyFileName);
       }
 
@@ -1072,7 +1072,7 @@ static void _species_init( void) {
         case 4:
           Species[sp]->disturbclass = VeryInsensitive; break;
         default:
-          LogError(&LogInfo, LOGFATAL, "%s: Incorrect disturbance class found",
+          LogError(&LogInfo, LOGERROR, "%s: Incorrect disturbance class found",
                   MyFileName);
       }
 
@@ -1101,7 +1101,7 @@ static void _species_init( void) {
     }/* end while*/
 
    if (!sppok) {
-      LogError(&LogInfo, LOGFATAL, "%s: Incorrect/incomplete input",
+      LogError(&LogInfo, LOGERROR, "%s: Incorrect/incomplete input",
               MyFileName);
    }
 
@@ -1120,13 +1120,13 @@ static void _species_init( void) {
      x=sscanf( inbuf, "%s %hd %f %hd %f",
                name, &viable, &xdecay, &pseed, &var);
      if (x < 5) {
-       LogError(&LogInfo, LOGFATAL, "%s: Too few columns in annual estab parms",
+       LogError(&LogInfo, LOGERROR, "%s: Too few columns in annual estab parms",
                MyFileName);
      }
 
      sp = Species_Name2Index(name);
      if (sp < 0) {
-       LogError(&LogInfo, LOGFATAL, "%s: Mismatched name (%s) for annual estab parms",
+       LogError(&LogInfo, LOGERROR, "%s: Mismatched name (%s) for annual estab parms",
                MyFileName, name);
      }
 
@@ -1158,7 +1158,7 @@ static void _species_init( void) {
    } /* end while readspp*/
 
    if (!sppok) {
-      LogError(&LogInfo, LOGFATAL, "%s: Incorrect/incomplete input in annual estab parms",
+      LogError(&LogInfo, LOGERROR, "%s: Incorrect/incomplete input in annual estab parms",
               MyFileName);
    }
 
@@ -1176,13 +1176,13 @@ static void _species_init( void) {
       x=sscanf( inbuf, "%s %f %f %f %f",
                 name, &p1, &p2, &p3, &p4);
       if (x < 5) {
-        LogError(&LogInfo, LOGFATAL, "%s: Too few columns in species probs",
+        LogError(&LogInfo, LOGERROR, "%s: Too few columns in species probs",
                 MyFileName);
       }
 
       sp = Species_Name2Index(name);
       if (sp < 0) {
-        LogError(&LogInfo, LOGFATAL, "%s: Mismatched name (%s) for species probs",
+        LogError(&LogInfo, LOGERROR, "%s: Mismatched name (%s) for species probs",
                 MyFileName, name);
       }
 
@@ -1192,7 +1192,7 @@ static void _species_init( void) {
       Species[sp]->prob_veggrow[Disturbance] = p4;
     } /* end while readspp*/
    if (!sppok) {
-      LogError(&LogInfo, LOGFATAL, "%s: Incorrect/incomplete input in probs",
+      LogError(&LogInfo, LOGERROR, "%s: Incorrect/incomplete input in probs",
               MyFileName);
    }
 
@@ -1211,12 +1211,12 @@ static void _species_init( void) {
     x = sscanf( inbuf, "%s %hd %f %f %f %f",
                 name, &turnondispersal, &p1, &HMAX, &PMD, &HSlope); 
     if(x < 6) {
-      LogError(&LogInfo, LOGFATAL, "%s: Too few columns in species seed dispersal inputs", MyFileName);
+      LogError(&LogInfo, LOGERROR, "%s: Too few columns in species seed dispersal inputs", MyFileName);
     }
 
     sp = Species_Name2Index(name);
     if(sp < 0){
-      LogError(&LogInfo, LOGFATAL, "%s: Mismatched name (%s) for species seed dispersal inputs", MyFileName, name);
+      LogError(&LogInfo, LOGERROR, "%s: Mismatched name (%s) for species seed dispersal inputs", MyFileName, name);
     }
 
     Species[sp]->use_dispersal = itob(turnondispersal);
@@ -1226,7 +1226,7 @@ static void _species_init( void) {
     Species[sp]->heightSlope = HSlope;
   }
   if(!sppok) {
-	  LogError(&LogInfo, LOGFATAL, "%s: Incorrect/incomplete input in species seed dispersal input", MyFileName);
+	  LogError(&LogInfo, LOGERROR, "%s: Incorrect/incomplete input in species seed dispersal input", MyFileName);
   }
    
    Mem_Free(name);

--- a/ST_resgroups.c
+++ b/ST_resgroups.c
@@ -38,7 +38,7 @@
 /* =================================================== */
 /*                  Global Variables                   */
 /* --------------------------------------------------- */
-pcg32_random_t resgroups_rng;
+sw_random_t resgroups_rng;
 
 
 /******** Modular External Function Declarations ***********/

--- a/ST_resgroups.c
+++ b/ST_resgroups.c
@@ -179,7 +179,8 @@ static RealF _add_annuals(const GrpIndex rg, const SppIndex sp, const RealF last
 
     /* Create a beta random number draw based on alpha and beta for each species
      * (calculated based on mean (s->seedling_estab_prob and variance (s->var)) */
-     var = RandBeta(Species[sp]->alpha, Species[sp]->beta, &resgroups_rng);
+     var = RandBeta(Species[sp]->alpha, Species[sp]->beta, &resgroups_rng,
+                    &LogInfo);
 
     /*Determine number of seedlings to add. If the number of seeds calculated
      * from the random draw is larger than max_seed_estab, max_seed_estab is used instead*/
@@ -987,7 +988,7 @@ GrpIndex RGroup_New(void)
 
 	if (++Globals->grpCount > SuperGlobals.max_rgroups)
 	{
-		LogError(&LogInfo, LOGFATAL, "Too many groups specified (>%d)!\n"
+		LogError(&LogInfo, LOGERROR, "Too many groups specified (>%d)!\n"
 				"You must adjust MAX_RGROUPS in maxrgroupspecies.in!",
 		SuperGlobals.max_rgroups);
 	}

--- a/ST_seedDispersal.c
+++ b/ST_seedDispersal.c
@@ -60,7 +60,7 @@ DispersalEvent* _lastEvent = NULL;
  * \brief The random number generator for the seed dispersal module.
  * \ingroup SEED_DISPERSAL_PRIVATE
  */
-pcg32_random_t dispersal_rng;
+sw_random_t dispersal_rng;
 
 /**
  * \brief TRUE if \ref dispersal_rng has already been seeded.

--- a/ST_seedDispersal.h
+++ b/ST_seedDispersal.h
@@ -41,7 +41,7 @@ typedef struct dispersal_event_st {
 /* --------------------------------------------------- */
 extern Bool UseSeedDispersal;
 extern Bool recordDispersalEvents;
-extern pcg32_random_t dispersal_rng;
+extern sw_random_t dispersal_rng;
 extern Bool outputSDData;
 
 /* =================================================== */

--- a/ST_species.c
+++ b/ST_species.c
@@ -22,6 +22,7 @@
 #include <string.h>
 #include "ST_steppe.h"
 #include "ST_globals.h"
+#include "sw_src/include/SW_datastructs.h"
 #include "sw_src/include/filefuncs.h"
 #include "sw_src/include/myMemory.h"
 #include "sw_src/include/rands.h"
@@ -32,7 +33,7 @@
 /* =================================================== */
 /*                  Global Variables                   */
 /* --------------------------------------------------- */
-pcg32_random_t species_rng;
+sw_random_t species_rng;
 
 
 

--- a/ST_species.c
+++ b/ST_species.c
@@ -166,7 +166,7 @@ void Species_Add_Indiv(SppIndex sp, Int new_indivs)
 	{
 		if (!indiv_New(sp))
 		{
-			LogError(&LogInfo, LOGFATAL, "Unable to add new individual in Species_Add_Indiv()");
+			LogError(&LogInfo, LOGERROR, "Unable to add new individual in Species_Add_Indiv()");
 		}
 
 		Species[sp]->est_count++;
@@ -312,7 +312,7 @@ SppIndex species_New(void)
 
 	if (++Globals->sppCount > MAX_SPECIES)
 	{
-		LogError(&LogInfo, LOGFATAL, "Too many species specified (>%d)!\n"
+		LogError(&LogInfo, LOGERROR, "Too many species specified (>%d)!\n"
 				"You must adjust MAX_SPECIES and recompile!\n",
 		MAX_SPECIES);
 	}

--- a/makefile
+++ b/makefile
@@ -137,7 +137,7 @@ clean: cleanobjs cleanbin documentation_clean
 .PHONY: cleanobjs
 cleanobjs:
 	-@find . -type f -name '*.o' -delete
-	-@$(RM) -f $(path_sw2lib)/$(lib_sw2)
+	-@(cd $(path_sw2) && $(MAKE) clean_build)
 
 .PHONY: cleanbin
 cleanbin:

--- a/sxw.c
+++ b/sxw.c
@@ -514,7 +514,7 @@ static void  _read_files( void ) {
   }
 
   if (i < nfiles) {
-    LogError(&LogInfo, LOGFATAL, "STEPWAT: %s: Insufficient files found",
+    LogError(&LogInfo, LOGERROR, "STEPWAT: %s: Insufficient files found",
             MyFileName);
   }
 
@@ -541,7 +541,7 @@ static void  _read_roots_max(void) {
 		p = strtok(inbuf, " \t"); /* g'teed to work via GetALine() */
 
 		if ((g = RGroup_Name2Index(p)) < 0) {
-			LogError(&LogInfo, LOGFATAL, "%s: Invalid group name (%s) found.",
+			LogError(&LogInfo, LOGERROR, "%s: Invalid group name (%s) found.",
 					MyFileName, p);
 		}
 		strcpy(name, p);
@@ -552,14 +552,14 @@ static void  _read_roots_max(void) {
 			lyr++;
 		}
 		if (lyr != SXW->NTrLyrs) {
-			LogError(&LogInfo, LOGFATAL,
+			LogError(&LogInfo, LOGERROR,
 					"%s: Group : %s : Missing layer values. Match up with soils.in file. Include zeros if necessary. Layers needed %u. Layers defined %u",
 					MyFileName, name, SXW->NTrLyrs, lyr);
 		}
 	}
 
 	if (cnt < Globals->grpCount) {
-		LogError(&LogInfo, LOGFATAL, "%s: Not enough valid groups found.",
+		LogError(&LogInfo, LOGERROR, "%s: Not enough valid groups found.",
 				MyFileName);
 	}
 
@@ -586,14 +586,14 @@ static void _read_phen(void) {
     p = strtok(inbuf," \t"); /* g'teed to work via GetALine() */
 
     if ( (g=RGroup_Name2Index(p)) <0 ) {
-      LogError(&LogInfo, LOGFATAL,
+      LogError(&LogInfo, LOGERROR,
                "%s: Invalid group name (%s) found.", MyFileName, p);
     }
     cnt++;
     m = Jan;
     while ((p=strtok(NULL," \t")) ) {
       if (m > Dec) {
-        LogError(&LogInfo, LOGFATAL,
+        LogError(&LogInfo, LOGERROR,
                  "%s: More than 12 months of data found.", MyFileName);
       }
       SXWResources->_phen[Igp(g,m)] = atof(p);
@@ -603,7 +603,7 @@ static void _read_phen(void) {
   }
 
   if (cnt < Globals->grpCount) {
-    LogError(&LogInfo, LOGFATAL,
+    LogError(&LogInfo, LOGERROR,
              "%s: Not enough valid groups found.", MyFileName);
   }
 
@@ -644,14 +644,14 @@ static void _read_prod(void) {
 
 		p = strtok(inbuf, " \t"); /* guaranteed to work via GetALine() */
 		if ((g = RGroup_Name2Index(p)) < 0) {
-			LogError(&LogInfo, LOGFATAL, "%s: Invalid group name for LITTER (%s).",
+			LogError(&LogInfo, LOGERROR, "%s: Invalid group name for LITTER (%s).",
 					MyFileName, p);
 		}
 
 		month = Jan;
 		while ((p = strtok(NULL, " \t"))) {
 			if (month > Dec) {
-				LogError(&LogInfo, LOGFATAL,
+				LogError(&LogInfo, LOGERROR,
 						"%s: More than 12 months of data found for LITTER.", MyFileName);
 			}
 			SXWResources->_prod_litter[g][month] = atof(p);
@@ -664,7 +664,7 @@ static void _read_prod(void) {
 	}
 
 	if (count < Globals->grpCount) {
-		LogError(&LogInfo, LOGFATAL, "%s: Not enough valid groups found for LITTER values.",
+		LogError(&LogInfo, LOGERROR, "%s: Not enough valid groups found for LITTER values.",
 				 MyFileName);
 	}
 
@@ -680,13 +680,13 @@ static void _read_prod(void) {
 		p = strtok(inbuf, " \t"); /* guaranteed to work via GetALine() */
 
 		if ((g = RGroup_Name2Index(p)) < 0) {
-			LogError(&LogInfo, LOGFATAL, "%s: Invalid group name for biomass (%s) found.",
+			LogError(&LogInfo, LOGERROR, "%s: Invalid group name for biomass (%s) found.",
 					MyFileName, p);
 		}
 		month = Jan;
 		while ((p = strtok(NULL, " \t"))) {
 			if (month > Dec) {
-				LogError(&LogInfo, LOGFATAL,
+				LogError(&LogInfo, LOGERROR,
 						"%s: More than 12 months of data found.", MyFileName);
 			}
 			SXWResources->_prod_bmass[Igp(g, month)] = atof(p);
@@ -698,7 +698,7 @@ static void _read_prod(void) {
 	}
 
 	if (count < Globals->grpCount) {
-		LogError(&LogInfo, LOGFATAL, "%s: Not enough valid groups found.",
+		LogError(&LogInfo, LOGERROR, "%s: Not enough valid groups found.",
 				MyFileName);
 	}
 
@@ -714,14 +714,14 @@ static void _read_prod(void) {
 		p = strtok(inbuf, " \t"); /* guaranteed to work via GetALine() */
 
 		if ((g = RGroup_Name2Index(p)) < 0) {
-			LogError(&LogInfo, LOGFATAL,
+			LogError(&LogInfo, LOGERROR,
 					"%s: Invalid group name for pctlive (%s) found.",
 					MyFileName, p);
 		}
 		month = Jan;
 		while ((p = strtok(NULL, " \t"))) {
 			if (month > Dec) {
-				LogError(&LogInfo, LOGFATAL,
+				LogError(&LogInfo, LOGERROR,
 						"%s: More than 12 months of data found.", MyFileName);
 			}
 			SXWResources->_prod_pctlive[Igp(g, month)] = atof(p);
@@ -733,7 +733,7 @@ static void _read_prod(void) {
 	}
 
 	if (count < Globals->grpCount) {
-		LogError(&LogInfo, LOGFATAL, "%s: Not enough valid groups found.",
+		LogError(&LogInfo, LOGERROR, "%s: Not enough valid groups found.",
 				MyFileName);
 	}
 
@@ -774,7 +774,7 @@ static void _read_watin(void) {
    CloseFile(&f, &LogInfo);
 
    if (!found) {
-     LogError(&LogInfo, LOGFATAL,
+     LogError(&LogInfo, LOGERROR,
               "%s: Too few files (%d)", MyFileName, lineno);
    }
 
@@ -932,7 +932,7 @@ static void _read_debugfile(void) {
 	}
 	strcat(errstr, "Note that data will always be appended,\n");
 	strcat(errstr, "so clear file contents before re-use.\n");
-	LogError(&LogInfo, LOGNOTE, errstr);
+	LogError(&LogInfo, LOGWARN, errstr);
 
 	CloseFile(&f, &LogInfo);
 

--- a/sxw.c
+++ b/sxw.c
@@ -68,7 +68,6 @@
 #include "sw_src/include/SW_Markov.h"
 #include "sw_src/include/SW_Output.h"
 #include "sw_src/include/rands.h"
-#include "sw_src/external/pcg/pcg_basic.h"
 #include "sw_src/include/SW_Times.h"
 
 
@@ -76,7 +75,7 @@
 /***********************************************************/
 SXW_t* SXW;
 SXW_resourceType* SXWResources;
-pcg32_random_t resource_rng; //rng for swx_resource.c functions.
+sw_random_t resource_rng; //rng for swx_resource.c functions.
 
 
 

--- a/sxw.h
+++ b/sxw.h
@@ -26,7 +26,6 @@
 
 #include "ST_defines.h"
 #include "sw_src/include/SW_Defines.h"
-#include "sw_src/external/pcg/pcg_basic.h"
 
 
 
@@ -189,7 +188,7 @@ typedef struct temp_SXW_st{
 /* --------------------------------------------------- */
 extern SXW_t *SXW;
 extern SXW_resourceType *SXWResources;
-extern pcg32_random_t resource_rng;
+extern sw_random_t resource_rng;
 extern transp_t *transp_window;
 
 #endif

--- a/sxw_resource.c
+++ b/sxw_resource.c
@@ -306,7 +306,7 @@ static void _transp_contribution_by_group(RealF use_by_group[]) {
             // This transpiration will be added
             transp_window->added_transp = (1 - transp_ratio / RandUniFloatRange(min, max, &resource_rng)) * transp_window->average;
             if(transp_window->added_transp < 0){
-                LogError(&LogInfo, LOGNOTE, "sxw_resource: Added transpiration less than 0.\n");
+                LogError(&LogInfo, LOGWARN, "sxw_resource: Added transpiration less than 0.\n");
             }
             //printf("Year %d:\tTranspiration to add: %f\n",Globals->currYear,add_transp);
 

--- a/sxw_resource.c
+++ b/sxw_resource.c
@@ -29,7 +29,6 @@
 #include "sw_src/include/SW_VegProd.h"
 #include "sw_src/include/SW_Files.h"
 #include "sw_src/include/SW_Times.h"
-#include "sw_src/external/pcg/pcg_basic.h"
 
 
 

--- a/sxw_soilwat.c
+++ b/sxw_soilwat.c
@@ -105,10 +105,10 @@ void _sxw_generate_weather(void) {
   SW_WEATHER *w = &SoilWatAll.Weather;
   SW_SKY *sky = &SoilWatAll.Sky;
 
-  deallocateAllWeather(w);
+  deallocateAllWeather(w->allHist, w->n_years);
   w->n_years = 1;
   w->startYear = SoilWatAll.Model.startyr + Globals->currYear - 1;
-  allocateAllWeather(w);
+  allocateAllWeather(&w->allHist, w->n_years, &LogInfo);
 
   if (!w->use_weathergenerator_only) {
     LogError(

--- a/test/test_ST_mortality.cc
+++ b/test/test_ST_mortality.cc
@@ -5,8 +5,7 @@
 TEST(ST_Mortality_test, Simulate_prescribed_fire_when_killfreq_startyr_is_0) {
     GrpIndex rg = 0;
     LOG_INFO local_log;
-    local_log.logged = swFALSE;
-    local_log.logfp = NULL;
+    sw_init_logs(NULL, &LogInfo);
 
     RGroup = (GroupType **)Mem_Calloc(1, sizeof(GroupType *), nullptr, &local_log);
     RGroup[rg] = (GroupType *)Mem_Calloc(1, sizeof(GroupType), nullptr, &local_log);


### PR DESCRIPTION
See https://github.com/DrylandEcology/SOILWAT2/pull/372

* Simulation output remains the same as the previous version.

* SOILWAT2 updated handling of warnings and errors (but functionality for STEPWAT2 is identical, i.e., immediate crash on error) ([SOILWAT2 issue 368](https://github.com/DrylandEcology/SOILWAT2/issues/368)).

* SOILWAT2 now offers `sw_random_t` for random numbers and internalizes all uses of `pcg` ([SOILWAT2 issue 373](https://github.com/DrylandEcology/SOILWAT2/issues/373)).

* Obsolete code in DEBUG_MEM* sections is removed ([SOILWAT2 issue 369](https://github.com/DrylandEcology/SOILWAT2/issues/369)).