### PR TITLE
SOILWAT2 Version 8.4.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "sw_src"]
 	path = sw_src
 	url = https://github.com/DrylandEcology/SOILWAT2.git
-	branch = master
+	branch = release/devel_v8.4.0
         ignore = dirty

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "sw_src"]
 	path = sw_src
 	url = https://github.com/DrylandEcology/SOILWAT2.git
-	branch = release/devel_v8.4.0
+	branch = master
         ignore = dirty

--- a/ST_grid.c
+++ b/ST_grid.c
@@ -269,10 +269,10 @@ void runGrid(void)
 
 
   _init_soilwat_outputs(grid_files[GRID_FILE_SOILWAT2_OUTPUT]);
-    SW_OUT_set_ncol(SoilWatDomain.nMaxSoilLayers, SoilWatDomain.nMaxEvapLayers,
-                    SoilWatRun.VegEstabIn.count, SoilWatDomain.OutDom.ncol_OUT,
-                    SoilWatDomain.OutDom.nvar_OUT, SoilWatDomain.OutDom.nsl_OUT,
-                    SoilWatDomain.OutDom.npft_OUT, &LogInfo); // set number of output columns
+    SW_OUT_set_ncol(SoilWatDomain.nMaxSoilLayers, SoilWatRun.VegEstabIn.count,
+                    SoilWatDomain.OutDom.ncol_OUT, SoilWatDomain.OutDom.nvar_OUT,
+                    SoilWatDomain.OutDom.nsl_OUT, SoilWatDomain.OutDom.npft_OUT,
+                    &LogInfo); // set number of output columns
 	SW_OUT_set_colnames(SoilWatRun.RunIn.SiteRunIn.n_layers, SoilWatRun.VegEstabIn.parms,
  						SoilWatDomain.OutDom.ncol_OUT,
  						SoilWatDomain.OutDom.colnames_OUT, &LogInfo); // set column names for output files
@@ -1055,6 +1055,7 @@ void load_cell(int row, int col){
         set_soillayers(
             &SoilWatRun.VegProdIn,
             &SoilWatRun.SiteIn,
+            &SoilWatRun.RunIn.SiteRunIn,
             &SoilWatRun.SiteSim,
             &SoilWatRun.RunIn.SoilRunIn,
             SoilWatRun.VegProdIn.veg,
@@ -1098,7 +1099,7 @@ void load_cell(int row, int col){
 	SW_FLW_init_run(&SoilWatRun.SoilWatSim);
 	SW_ST_init_run(&SoilWatRun.StRegSimVals);
 	SW_SWC_init_run(&SoilWatRun.SoilWatSim, &SoilWatRun.SiteSim,
- 					&SoilWatRun.WeatherSim.temp_snow, SoilWatRun.RunIn.SiteRunIn.n_layers);
+ 					&SoilWatRun.WeatherSim.temp_snow, &SoilWatRun.WeatherSim.snow_age, SoilWatRun.RunIn.SiteRunIn.n_layers);
 }
 
 /**

--- a/ST_main.c
+++ b/ST_main.c
@@ -204,10 +204,10 @@ int main(int argc, char **argv) {
 	parm_Initialize();
         
 	SXW_Init(TRUE, NULL); // allocate SOILWAT2-memory
-	SW_OUT_set_ncol(SoilWatDomain.nMaxSoilLayers, SoilWatDomain.nMaxEvapLayers,
-                    SoilWatRun.VegEstabIn.count, SoilWatDomain.OutDom.ncol_OUT,
-                    SoilWatDomain.OutDom.nvar_OUT, SoilWatDomain.OutDom.nsl_OUT,
-                    SoilWatDomain.OutDom.npft_OUT, &LogInfo); // set number of output columns
+	SW_OUT_set_ncol(SoilWatDomain.nMaxSoilLayers, SoilWatRun.VegEstabIn.count,
+                    SoilWatDomain.OutDom.ncol_OUT, SoilWatDomain.OutDom.nvar_OUT,
+                    SoilWatDomain.OutDom.nsl_OUT, SoilWatDomain.OutDom.npft_OUT,
+                    &LogInfo); // set number of output columns
  	SW_OUT_set_colnames(SoilWatRun.RunIn.SiteRunIn.n_layers, SoilWatRun.VegEstabIn.parms,
  						SoilWatDomain.OutDom.ncol_OUT,
  						SoilWatDomain.OutDom.colnames_OUT, &LogInfo); // set column names for output files

--- a/sxw.c
+++ b/sxw.c
@@ -286,17 +286,14 @@ static void SXW_Reinit(char* SOILWAT_file, Bool zeroOutArrays) {
         &SoilWatDomain.SW_PathInputs,
         SoilWatDomain.hasConsistentSoilLayerDepths,
         &SoilWatDomain.nMaxSoilLayers,
-        &SoilWatDomain.nMaxEvapLayers,
         SoilWatDomain.depthsAllSoilLayers,
         SoilWatRun.RunIn.SiteRunIn.n_layers,
-        SoilWatRun.SiteSim.n_evap_lyrs,
         SoilWatRun.RunIn.SoilRunIn.depths,
         &LogInfo
     );
 
     SW_OUT_setup_output(
         SoilWatDomain.nMaxSoilLayers,
-        SoilWatDomain.nMaxEvapLayers,
         SoilWatRun.VegEstabIn.count,
         SoilWatRun.VegEstabIn.parms,
         &SoilWatDomain.OutDom,

--- a/sxw_soilwat.c
+++ b/sxw_soilwat.c
@@ -148,7 +148,7 @@ void _sxw_generate_weather(void) {
     );
 
   finalizeAllWeather(&SoilWatRun.MarkovIn, w, *wh, SoilWatRun.ModelSim.cum_monthdays,
-                      SoilWatRun.ModelSim.days_in_month, NULL, FALSE, &LogInfoSW); // run the weather
+                      SoilWatRun.ModelSim.days_in_month, &LogInfoSW); // run the weather
 }
 
 

--- a/testing.sagebrush.master/Stepwat_Inputs/Input/sxw/Input/outsetup.in
+++ b/testing.sagebrush.master/Stepwat_Inputs/Input/sxw/Input/outsetup.in
@@ -73,6 +73,7 @@ TIMESTEP dy mo yr # must be lowercase
       BIOMASS     AVG       DY       1     end      vegetation      /* vegetation: cover (%) for trees, shrubs, forbs, grasses; biomass (g/m2 as component of total) for total, trees, shrubs, forbs, grasses, and litter; live biomass (g/m2 as component of total) total, trees, shrubs, forbs, grasses; leaf area index LAI (m2/m2) */
    DERIVEDSUM     SUM       DY       1     end      derivedsum      /* cumulative derived metrics: cwd, ddd5C30bar000to100cm, wdd5C15bar000to100cm */
    DERIVEDAVG     AVG       DY       1     end      derivedavg      /* average derived metrics: swa30bar000to100cm, swa39bar000to100cm */
+   ENERGYAVG     AVG       DY       1     end       energyavg      /* surface albedo */
 
 # Simulation output directory/filenames
 Output/			# Path for output files: / for same directory, or e.g., Output/

--- a/testing.sagebrush.master/Stepwat_Inputs/Input/sxw/Input/siteparam.in
+++ b/testing.sagebrush.master/Stepwat_Inputs/Input/sxw/Input/siteparam.in
@@ -16,20 +16,47 @@
 15.0		# swc_wet : [cm/cm] if < 1.0, [-bars] if >= 1.0.
 
 #---- Diffuse recharge and runoff/runon
-0		# reset (1/0): do/don't reset soil water content for each year
-1		# deepdrain (1/0): allow/disallow deep drainage (diffuse recharge)
-1.0		# multiplier for PET (e.g., for climate change scenarios)
-0.0		# proportion of ponded surface water removed as daily runoff (value ranges between 0 and 1; 0=no loss of surface water, 1=all ponded water lost via runoff)
-0.0		# proportion of water that arrives at surface added as daily runon [from a hypothetical identical neighboring site] (value ranges between 0 and +inf; 0=no runon, >0: runon is occuring)
+0       # reset (1/0): do/don't reset soil water content for each year
+1       # deepdrain (1/0): allow/disallow deep drainage (diffuse recharge)
+0.0     # proportion of ponded surface water removed as daily runoff
+        #   (0-1; 0=no loss of surface water, 1=all ponded water lost via runoff)
+0.0     # proportion of water that arrives at surface added as daily runon
+        #   [from a hypothetical identical neighboring site]
+        #   (value ranges between 0 and +inf; 0=no runon, >0: runon is occuring)
+
+#---- Energy, albedo and atmospheric demand
+1.0     # multiplier for PET (e.g., for climate change scenarios)
+
+0.01    # Ground surface roughness length (z_0g) [m]
+        #   default 0.01 for bare soil (Niu & Yang 2007)
+
+0       # method for surface albedo (methodAlbedo)
+        #   0 (albedoFixed), cover-weighted sum over PFTs and bare ground
+        #       with fixed values (before v8.4.0)
+        #   1 (albedoDynamic1), dynamic vegetation, soil and snow albedos
+        #       (recommended since v8.4.0)
+
+0.85    # Fresh snow albedo (alpha_snow_max) [unitless] (Livneh et al. 2010)
+0.46    # Soil albedo at zero moisture (alpha_soil_dry) [unitless]
+0.15    # Saturated soil albedo (alpha_soil_sat) [unitless]
+5.1     # Shape parameter for soil albedo darkening with moisture
+        #   (paramSoilAlbedoDarkening) [unitless].
+        #   Default estimated from Gascoin et al. 2009 decay term
+        #   exp(-B_g * theta) with B_g = 12.7,
+        #   while soil_albedo() uses exp(-B_sw2 * theta / theta_sat);
+        #   assuming theta_sat = 0.4, then B_sw2 = 12.7 * 0.4 = 5.1
 
 #---- Snow simulation
 # based on the SWAT2K model by Neitsch et al. (2005)
 # Current values are RMSE optimized based on 10 random SNOTEL sites for western US
-0.61		# TminAccu2 = Avg. air temp below which ppt is snow ( C)
-1.54		# TmaxCrit = Snow temperature at which snow melt starts ( C)
-0.1		# lambdasnow = Relative contribution of avg. air temperature to todays snow temperture vs. yesterday's snow temperature (0-1)
-0.0		# RmeltMin = Minimum snow melt rate on winter solstice (cm/day/C)
-0.27		# RmeltMax = Maximum snow melt rate on summer solstice (cm/day/C)
+0.61    # TminAccu2 = Avg. air temp below which ppt is snow ( C)
+1.54    # TmaxCrit = Snow temperature at which snow melt starts ( C)
+0.1     # lambdasnow = Relative contribution of avg. air temperature to
+        #   todays snow temperture vs. yesterday's snow temperature (0-1)
+0.0     # RmeltMin = Minimum snow melt rate on winter solstice (cm/day/C)
+0.27    # RmeltMax = Maximum snow melt rate on summer solstice (cm/day/C)
+1.0     # Shape factor of snow fractional cover relationship with snow density
+        #   (snowFractionalCoverMeltingFactor) [unitless] (Niu & Yang 2007)
 
 #---- Hydraulic conductivity
 0.02		# Parameter (cm / day) for unsaturated hydraulic conductivity,
@@ -56,24 +83,27 @@
 
 #---- Surface and soil temperature
 # from Parton 1978, ch. 2.2.2 Temperature-profile Submodel
-300.		# biomass limiter, 300 g/m^2 in Parton's equation for T1(avg daily temperature at the top of the soil)
-15.		# constant for T1 equation (used if biomass <= biomass limiter), 15 in Parton's equation
--4.		# constant for T1 equation (used if biomass > biomass limiter), -4 in Parton's equation
-600.		# constant for T1 equation (used if biomass > biomass limiter), 600 in Parton's equation
-0.00070		# constant for cs (soil-thermal conductivity) equation, 0.00070 in Parton's equation
-0.00030		# constant for cs equation, 0.00030 in Parton's equation
-0.18		# constant for sh (specific heat capacity) equation, 0.18 in Parton's equation
-6.69		# constant soil temperature (Celsius) at the lower boundary (max depth); approximate by mean annual air temperature of site
-15.		# deltaX parameter for soil_temperature function, default is 15.  (distance between profile points in cm)  max depth (the next number) should be evenly divisible by this number
-990.		# max depth for the soil_temperature function equation, default is 990.  this number should be evenly divisible by deltaX
-0		# flag, 1 to calculate soil_temperature, 0 to not calculate soil_temperature
+300.    # biomass limiter, 300 g/m^2 in Parton's equation for T1(avg daily temperature at the top of the soil)
+15.     # constant for T1 equation (used if biomass <= biomass limiter), 15 in Parton's equation
+-4.     # constant for T1 equation (used if biomass > biomass limiter), -4 in Parton's equation
+600.    # constant for T1 equation (used if biomass > biomass limiter), 600 in Parton's equation
+0.00070 # constant for cs (soil-thermal conductivity) equation, 0.00070 in Parton's equation
+0.00030 # constant for cs equation, 0.00030 in Parton's equation
+0.18    # constant for sh (specific heat capacity) equation, 0.18 in Parton's equation
+6.69    # constant soil temperature (Celsius) at the lower boundary (max depth); approximate by mean annual air temperature of site
+15.     # deltaX parameter for soil_temperature function, default is 15.  (distance between profile points in cm)  max depth (the next number) should be evenly divisible by this number
+990.    # max depth for the soil_temperature function equation, default is 990.  this number should be evenly divisible by deltaX
+
+0       # flag, 1 to calculate soil_temperature, 0 to not calculate soil_temperature
+
 1       # Method for average surface temperature:
-        #     0, default prior to v8.1.0 (Parton 1978)
-        #     1, default since v8.1.0 (Parton 1984)
+        #   0, default prior to v8.1.0 (Parton 1978)
+        #   1, default since v8.1.0 (Parton 1984)
 
 0       # Method for soil temperature at maximum depth:
-        #     0, user provided value (default prior to v8.3.0)
-        #     1, dynamically calculated from a moving long-term mean annual air temperature (recommended since v8.3.0)
+        #   0, user provided value (default prior to v8.3.0)
+        #   1, dynamically calculated from a moving long-term mean annual
+        #       air temperature (recommended since v8.3.0)
 
 # ---- CO2 Settings ----
 # Activate (1) / deactivate (0) biomass multiplier
@@ -88,10 +118,18 @@ RCP85
 # Simulated soil layer number determination:
 #   txt-mode: layers provided in "soils.in" and "swrc_params.in"
 
-1   # 1 = depths/thickness of soil layers are equal among sites/gridcells
+1   # 0 = depth/thickness of soil layers vary among sites/gridcells
+    # 1 = depths/thickness of soil layers are equal among sites/gridcells
 
-# Are inputs of density representing bulk soil (type 1) or the matric component (type 0)?
-0
+0   # Soil density inputs represent bulk soil (type 1) or the matric component (type 0)?
+
+# Method for potential soil evaporation coefficients
+0   # 0 = Inputs for evco provided via "soils.in"
+    # 1 = Estimation of evco from relationship with soil properties
+
+# Method for rooting profile inputs
+0   # 0 = Inputs for trco provided via "soils.in"
+    # 1 = Estimation of trco with equation and parameters from "veg.in"
 
 
 # --- Organic matter ---

--- a/testing.sagebrush.master/Stepwat_Inputs/Input/sxw/Input/veg.in
+++ b/testing.sagebrush.master/Stepwat_Inputs/Input/sxw/Input/veg.in
@@ -2,7 +2,7 @@
 # Location:
 
 #---- Select method for vegetation parameters
-0       # 0 - Use values from this file
+0       # 0 - Use composition and biomass inputs from veg.in
         # 1 - Estimate vegetation composition from long-term climate conditions
         #     (values for other vegetation parameters from this file)
         # 2 - Dynamic vegetation using short- and long-term conditions
@@ -31,7 +31,24 @@
 
 # ---- Albedo
 #	treeNL	treeBL	shrub	forbs	grassC3	grassC4	BareGround
+
+# Legacy values (SOILWAT2 < v8.4.0)
 	0.106	0.106	0.143	0.167	0.167	0.167	0.15
+
+# White-sky shortwave MODIS albedo for pure IGBP cells: Houldcroft et al. 2009, Table 3
+#	1		4		7		10		10		9		-
+#	0.106	0.168	0.143	0.167	0.167	0.156	0.15
+
+# White-sky shortwave MODIS albedo for JULES PFTs: Houldcroft et al. 2009, Table 4
+#	NL		BL		sh		C3g		C3g		C4g		-
+#	0.088	0.143	0.115	0.178	0.178	0.159	0.15
+
+# Extinction coefficient for calculating canopy albedo from leaf albedo
+# and leaf area index (LAI), default 0.5 for spherical leaf angle distribution
+# (Ross 1981; Houldcroft et al. 2009)
+
+#	treeNL	treeBL	shrub	forbs	grassC3	grassC4
+	0.5		0.5		0.5		0.5		0.5		0.5
 
 
 # -- Canopy height (cm) parameters either constant through season or as tanfunc with respect to biomass (g/m^2)
@@ -72,6 +89,20 @@
 	0.		0.		12.		12.		12.		12.		# yinflec
 	2.		2.		34.		34.		34.		34.		# range
 	0.0002	0.0002	0.002	0.002	0.002	0.002	# slope
+
+#--- Parametric root profiles (request via "siteparam.in")
+# Equation Y = 1 - 1 / 2 * (exp(- p1 * depth) + exp(- p2 * depth))
+# by Zeng (2001) J Hydrometeorology 2:525-530.
+# treeNL -- Evergreen needleleaf tree (Tables 1, 2, 3)
+# treeBL -- Deciduous broadleaf tree (Tables 1, 2, 3)
+# shrub -- Semidesert (Table 1); Barren (Table 2); Broadleaf shrubs with bare soil (Table 3)
+# forbs -- Crop/mixed farming (Table 1); Cropland/natural vegetation (Table 2); Agriculture/C3 grassland (Table 3)
+# grassC3 -- Crop/mixed farming (Table 1); Cropland/natural vegetation (Table 2); Agriculture/C3 grassland (Table 3)
+# grassC4 -- Short vegetation/C4 grassland (Table 3)
+#	treeNL	treeBL	shrub	forbs	grassC3	grassC4
+	6.706	5.990	4.372	5.558	5.558	7.795	# shape parameter 'a' [m-1]
+	2.175	1.955	0.978	2.614	2.614	1.862	# shape parameter 'b' [m-1]
+	1.800	2.000	4.000	1.500	1.500	2.100	# maximum rooting zone depth [m]
 
 
 # ---- Hydraulic redistribution: Ryel, Ryel R, Caldwell, Caldwell M, Yoder, Yoder C, Or, Or D, Leffler, Leffler A. 2002. Hydraulic redistribution in a stand of Artemisia tridentata: evaluation of benefits to transpiration assessed with a simulation model. Oecologia 130: 173-184.

--- a/testing.sagebrush.master/Stepwat_Inputs/Input/sxw/files_SOILWAT2.in
+++ b/testing.sagebrush.master/Stepwat_Inputs/Input/sxw/files_SOILWAT2.in
@@ -8,12 +8,12 @@ Input-nc/SW2_netCDF_output_variables.tsv
 
 #Domain
 Input/domain.in
+Input/modelrun.in	# years for model operation
 
 # Model
-Input/modelrun.in	# years for model operation
 Output/sw_output/logfile.log	# Output file to which warnings, errors, and other important information is written (can also be stdout)
 
-#Site
+#Logs
 Input/siteparam.in	# site parameters
 Input/soils.in	# soil layer definitions
 Input/swrc_params.in		# Input for soil water retention curve (used if pdf_type = 0, i.e., pedotransfer functions are not used)

--- a/tools/compare_bmassavg_against_ref.R
+++ b/tools/compare_bmassavg_against_ref.R
@@ -5,7 +5,6 @@
 # (e.g., on a development branch)
 # against a previously executed "reference" run (e.g., on the release branch)
 
-
 # Run this R code from within the directory of `STEPWAT2/` after
 # two non-gridded `STEPWAT2` simulations have been run in the testing directory
 # ```
@@ -23,24 +22,32 @@
 #-------------------------------------------
 
 #--- Define inputs ------
-dir <- "testing.sagebrush.master/Stepwat_Inputs/Output"
-dir_ref <- "testing.sagebrush.master/Stepwat_Inputs/Output_ref"
-fname_bmass <- "bmassavg.csv"
+isGridded <- FALSE
+
+if (isGridded) {
+    dir <- "testing.sagebrush.master/Output"
+    dir_ref <- "testing.sagebrush.master/Output_ref"
+    fname_bmass <- "all_cell_average_biomass.csv"
+} else {
+    dir <- "testing.sagebrush.master/Stepwat_Inputs/Output"
+    dir_ref <- "testing.sagebrush.master/Stepwat_Inputs/Output_ref"
+    fname_bmass <- "bmassavg.csv"
+}
 
 nyrs_meanbmass <- 200 # Used by Palmquist et al. 2021 GCB
 
 # rgroups from "Input/rgoup.in"
 rgroups <- c(
-  "sagebrush",
-  "a.cool.forb",
-  "a.warm.forb",
-  "p.cool.forb",
-  "p.warm.forb",
-  "a.cool.grass",
-  "p.cool.grass",
-  "p.warm.grass",
-  "shrub",
-  "succulents"
+    "sagebrush",
+    "a.cool.forb",
+    "a.warm.forb",
+    "p.cool.forb",
+    "p.warm.forb",
+    "a.cool.grass",
+    "p.cool.grass",
+    "p.warm.grass",
+    "shrub",
+    "succulents"
 )
 
 
@@ -51,21 +58,21 @@ x_ref <- read.csv(file.path(dir_ref, fname_bmass))
 ids_yrs <- max(1, nrow(x) - nyrs_meanbmass + 1):nrow(x)
 
 ids <-
-  apply(x[ids_yrs, rgroups], 2, max) > 0 |
-  apply(x_ref[ids_yrs, rgroups], 2, max) > 0
+    apply(x[ids_yrs, rgroups], 2, max) > 0 |
+    apply(x_ref[ids_yrs, rgroups], 2, max) > 0
 rgroups_used <- rgroups[ids]
 
 
 #--- Comparisons ------
 tagTest <- if (identical(basename(dir), "Output")) {
-  "test"
+    "test"
 } else {
-  sub("Output_", "", basename(dir))
+    sub("Output_", "", basename(dir))
 }
 tagRef <- if (identical(basename(dir), "Output_ref")) {
-  "reference"
+    "reference"
 } else {
-  sub("Output_", "", basename(dir_ref))
+    sub("Output_", "", basename(dir_ref))
 }
 
 nrgu <- length(rgroups_used)
@@ -82,102 +89,105 @@ meanxref <- colMeans(x_ref[ids_yrs, rgroups_used])
 n_panels <- c(3, 2)
 
 fname_tsc <- file.path(
-  dirname(dir),
-  paste0(
-    "Fig_TimeSeriesComparison_",
-    tagRef, "-vs-", tagTest, "_",
-    format(Sys.time(), "%Y%m%d-%H%M"),
-    ".pdf"
-  )
+    dirname(dir),
+    paste0(
+        "Fig_TimeSeriesComparison_",
+        tagRef,
+        "-vs-",
+        tagTest,
+        "_",
+        format(Sys.time(), "%Y%m%d-%H%M"),
+        ".pdf"
+    )
 )
 
 if (!file.exists(fname_tsc)) {
-  pdf(
-    file = fname_tsc,
-    height = n_panels[1] * 3,
-    width = n_panels[2] * 5
-  )
+    pdf(
+        file = fname_tsc,
+        height = n_panels[1] * 3,
+        width = n_panels[2] * 5
+    )
 
-  par_prev <- par(
-    mfrow = n_panels,
-    mar = c(2.5, 3, 3, 1),
-    mgp = c(1.5, 0, 0),
-    tcl = 0.3
-  )
+    par_prev <- par(
+        mfrow = n_panels,
+        mar = c(2.5, 3, 3, 1),
+        mgp = c(1.5, 0, 0),
+        tcl = 0.3
+    )
 
-  matplot(
-    x[, rgroups_used],
-    type = "l",
-    xlab = "Simulation time [Years]",
-    ylab = paste("Biomass of", tagTest, "[g/m2]"),
-    col = colors_rg,
-    lty = lty_rg,
-    main = "Biomass time-series"
-  )
-  points(rep(nrow(x) + 5, nrgu), meanx, col = colors_rg, pch = 4)
-  legend(
-    "topleft",
-    legend = rgroups_used,
-    col = colors_rg,
-    lwd = 3,
-    cex = 0.65
-  )
-  matplot(
-    x_ref[, rgroups_used],
-    type = "l",
-    xlab = "Simulation time [Years]",
-    ylab = paste("Biomass of", tagRef, "[g/m2]"),
-    col = colors_rg,
-    lty = lty_rg
-  )
-  points(rep(nrow(x_ref) + 5, nrgu), meanxref, col = colors_rg, pch = 4)
+    matplot(
+        x[, rgroups_used],
+        type = "l",
+        xlab = "Simulation time [Years]",
+        ylab = paste("Biomass of", tagTest, "[g/m2]"),
+        col = colors_rg,
+        lty = lty_rg,
+        main = "Biomass time-series"
+    )
+    points(rep(nrow(x) + 5, nrgu), meanx, col = colors_rg, pch = 4)
+    legend(
+        "topleft",
+        legend = rgroups_used,
+        col = colors_rg,
+        lwd = 3,
+        cex = 0.65
+    )
+    matplot(
+        x_ref[, rgroups_used],
+        type = "l",
+        xlab = "Simulation time [Years]",
+        ylab = paste("Biomass of", tagRef, "[g/m2]"),
+        col = colors_rg,
+        lty = lty_rg
+    )
+    points(rep(nrow(x_ref) + 5, nrgu), meanxref, col = colors_rg, pch = 4)
 
-  matplot(
-    x[, rgroups_used],
-    type = "l",
-    log = "y",
-    xlab = "Simulation time [Years]",
-    ylab = paste("Biomass of", tagTest, "[g/m2]"),
-    col = colors_rg,
-    lty = lty_rg,
-    main = "Biomass time-series on log-scale"
-  )
-  points(rep(nrow(x) + 5, nrgu), meanx, col = colors_rg, pch = 4)
-  matplot(
-    x_ref[, rgroups_used],
-    type = "l",
-    log = "y",
-    xlab = "Simulation time [Years]",
-    ylab = paste("Biomass of", tagRef, "[g/m2]"),
-    col = colors_rg,
-    lty = lty_rg
-  )
-  points(rep(nrow(x_ref) + 5, nrgu), meanxref, col = colors_rg, pch = 4)
+    matplot(
+        x[, rgroups_used],
+        type = "l",
+        log = "y",
+        xlab = "Simulation time [Years]",
+        ylab = paste("Biomass of", tagTest, "[g/m2]"),
+        col = colors_rg,
+        lty = lty_rg,
+        main = "Biomass time-series on log-scale"
+    )
+    points(rep(nrow(x) + 5, nrgu), meanx, col = colors_rg, pch = 4)
+    matplot(
+        x_ref[, rgroups_used],
+        type = "l",
+        log = "y",
+        xlab = "Simulation time [Years]",
+        ylab = paste("Biomass of", tagRef, "[g/m2]"),
+        col = colors_rg,
+        lty = lty_rg
+    )
+    points(rep(nrow(x_ref) + 5, nrgu), meanxref, col = colors_rg, pch = 4)
 
-  matplot(
-    x[, rgroups_used],
-    type = "l",
-    ylim = c(0, 200),
-    xlab = "Simulation time [Years]",
-    ylab = paste("Biomass of", tagTest, "[g/m2]"),
-    col = colors_rg,
-    lty = lty_rg,
-    main = "Biomass time-series on trimmed scale"
-  )
-  points(rep(nrow(x) + 5, nrgu), meanx, col = colors_rg, pch = 4)
-  matplot(
-    x_ref[, rgroups_used],
-    type = "l",
-    ylim = c(0, 200),
-    xlab = "Simulation time [Years]",
-    ylab = paste("Biomass of", tagRef, "[g/m2]"),
-    col = colors_rg,
-    lty = lty_rg
-  )
-  points(rep(nrow(x_ref) + 5, nrgu), meanxref, col = colors_rg, pch = 4)
+    matplot(
+        x[, rgroups_used],
+        type = "l",
+        ylim = c(0, 200),
+        xlab = "Simulation time [Years]",
+        ylab = paste("Biomass of", tagTest, "[g/m2]"),
+        col = colors_rg,
+        lty = lty_rg,
+        main = "Biomass time-series on trimmed scale"
+    )
+    points(rep(nrow(x) + 5, nrgu), meanx, col = colors_rg, pch = 4)
+    matplot(
+        x_ref[, rgroups_used],
+        type = "l",
+        ylim = c(0, 200),
+        xlab = "Simulation time [Years]",
+        ylab = paste("Biomass of", tagRef, "[g/m2]"),
+        col = colors_rg,
+        lty = lty_rg
+    )
+    points(rep(nrow(x_ref) + 5, nrgu), meanxref, col = colors_rg, pch = 4)
 
-  par(par_prev)
-  dev.off()
+    par(par_prev)
+    dev.off()
 }
 
 
@@ -185,70 +195,81 @@ if (!file.exists(fname_tsc)) {
 n_panels <- c(nrgu, 2)
 
 fname_scc <- file.path(
-  dirname(dir),
-  paste0(
-    "Fig_ScatterComparison_",
-    tagRef, "-vs-", tagTest, "_",
-    format(Sys.time(), "%Y%m%d-%H%M"),
-    ".pdf"
-  )
+    dirname(dir),
+    paste0(
+        "Fig_ScatterComparison_",
+        tagRef,
+        "-vs-",
+        tagTest,
+        "_",
+        format(Sys.time(), "%Y%m%d-%H%M"),
+        ".pdf"
+    )
 )
 
 if (!file.exists(fname_scc)) {
-  pdf(
-    file = fname_scc,
-    height = n_panels[1] * 3,
-    width = n_panels[2] * 3
-  )
-
-  par_prev <- par(
-    mfrow = n_panels,
-    mar = c(3.5, 4.5, 3, 1),
-    mgp = c(2, 0, 0),
-    tcl = 0.3
-  )
-
-  for (k in seq_len(nrgu)) {
-    tmpx <- x[ids_yrs, rgroups_used[k]]
-    tmpxref <- x_ref[ids_yrs, rgroups_used[k]]
-
-    vlim <- c(0, max(tmpx, tmpxref))
-    plot(
-      tmpxref,
-      tmpx,
-      col = colors_rg[k],
-      xlim = vlim,
-      ylim = vlim,
-      xlab = paste(
-        "\nBiomass of", tagRef, "[g/m2]\nmean =",
-        round(meanxref[k], 2)
-      ),
-      ylab = paste(
-        "Biomass of", tagTest, "[g/m2]\nmean =",
-        round(meanx[k], 2)
-      ),
-      main = rgroups_used[k]
+    pdf(
+        file = fname_scc,
+        height = n_panels[1] * 3,
+        width = n_panels[2] * 3
     )
-    abline(0, 1, col = "red", lty = 2)
-    abline(v = meanxref[k], h = meanx[k], col = "orange", lwd = 2)
 
-    diffs <- tmpxref - tmpx
-    tmp <- range(diffs)
-    vlim <- c(if (tmp[1] < 0) 1.05 else 0.95, 1.05) * tmp
-    hist(
-      diffs,
-      col = colors_rg[k],
-      xlim = vlim,
-      xlab = paste(
-        "\nBiomass of", tagRef, "-", tagTest, "[g/m2]\nmean =",
-        round(mean(diffs), 2)
-      ),
-      main = rgroups_used[k]
+    par_prev <- par(
+        mfrow = n_panels,
+        mar = c(3.5, 4.5, 3, 1),
+        mgp = c(2, 0, 0),
+        tcl = 0.3
     )
-    abline(v = 0, col = "red", lty = 2)
-    abline(v = mean(diffs), col = "orange", lwd = 2)
-  }
 
-  par(par_prev)
-  dev.off()
+    for (k in seq_len(nrgu)) {
+        tmpx <- x[ids_yrs, rgroups_used[k]]
+        tmpxref <- x_ref[ids_yrs, rgroups_used[k]]
+
+        vlim <- c(0, max(tmpx, tmpxref))
+        plot(
+            tmpxref,
+            tmpx,
+            col = colors_rg[k],
+            xlim = vlim,
+            ylim = vlim,
+            xlab = paste(
+                "\nBiomass of",
+                tagRef,
+                "[g/m2]\nmean =",
+                round(meanxref[k], 2)
+            ),
+            ylab = paste(
+                "Biomass of",
+                tagTest,
+                "[g/m2]\nmean =",
+                round(meanx[k], 2)
+            ),
+            main = rgroups_used[k]
+        )
+        abline(0, 1, col = "red", lty = 2)
+        abline(v = meanxref[k], h = meanx[k], col = "orange", lwd = 2)
+
+        diffs <- tmpxref - tmpx
+        tmp <- range(diffs)
+        vlim <- c(if (tmp[1] < 0) 1.05 else 0.95, 1.05) * tmp
+        hist(
+            diffs,
+            col = colors_rg[k],
+            xlim = vlim,
+            xlab = paste(
+                "\nBiomass of",
+                tagRef,
+                "-",
+                tagTest,
+                "[g/m2]\nmean =",
+                round(mean(diffs), 2)
+            ),
+            main = rgroups_used[k]
+        )
+        abline(v = 0, col = "red", lty = 2)
+        abline(v = mean(diffs), col = "orange", lwd = 2)
+    }
+
+    par(par_prev)
+    dev.off()
 }


### PR DESCRIPTION
- SOILWAT2 v8.4.0 PR for more information: https://github.com/DrylandEcology/SOILWAT2/pull/487

- Notable changes in SOILWAT2 v8.4.0 are:
    - New surface albedo calculations with dynamic snow, soil and vegetation components
    - Updated rooting profiles
    - The ability to end on any day of the year

- Relevant changes to STEPWAT2
    - Update SOILWAT2 input files to match SOILWAT2's and function interfaces

- Updated files
    - SOILWAT2 input: `files_SOILWAT2.in`, `outsetup.in`, `siteparam.in` and `veg.in`

- SOILWAT2 output remains the same except for new output column `ENERGYAVG_surfaceAlbedo`
    * A change in the number of output soil layers is also updated due to the removal of maximum evaporation layers